### PR TITLE
fix: increase `MarketIndex` from `u16` -> `u32`

### DIFF
--- a/programs/openbook-v2/src/logs.rs
+++ b/programs/openbook-v2/src/logs.rs
@@ -1,4 +1,4 @@
-use crate::state::{Market, Position};
+use crate::state::{Market, MarketIndex, Position};
 use anchor_lang::prelude::*;
 use borsh::BorshSerialize;
 
@@ -50,7 +50,7 @@ pub struct FillLog {
 #[event]
 pub struct MarketMetaDataLog {
     pub market: Pubkey,
-    pub market_index: u16,
+    pub market_index: MarketIndex,
     pub base_decimals: u8,
     pub quote_decimals: u8,
     pub base_lot_size: i64,

--- a/programs/openbook-v2/src/state/market.rs
+++ b/programs/openbook-v2/src/state/market.rs
@@ -9,7 +9,7 @@ use crate::{accounts_zerocopy::KeyedAccountReader, state::orderbook::Side};
 use super::{orderbook, OracleConfig, StablePriceModel};
 
 pub type TokenIndex = u16;
-pub type MarketIndex = u16;
+pub type MarketIndex = u32;
 
 #[account(zero_copy)]
 #[derive(Debug)]
@@ -28,7 +28,7 @@ pub struct Market {
     pub base_decimals: u8,
     pub quote_decimals: u8,
 
-    pub padding1: [u8; 3],
+    pub padding1: [u8; 1],
 
     /// Name. Trailing zero bytes are ignored.
     pub name: [u8; 16],
@@ -110,7 +110,7 @@ const_assert_eq!(
     1 + // size of bump
     1 + // size of base_decimals
     1 + // size of quote_decimals
-    3 + // size of padding1
+    1 + // size of padding1
     16 + // size of name
     3 * 32 + // size of bids, asks, and event_queue
     32 + // size of oracle


### PR DESCRIPTION
Gentlefolks, it is with utmost respect and regard that I present to thee an analysis of the present state of `MarketIndex` - verily, a `u16`. This allows for a respectable number of markets - 65,536 to be exact. 

However, at the Market's girth of 2744 bytes, someone can create a `Market` for the petite price of 0.01998912 SOL. Thusly, a malevolent griefer could use up every index for 1310 SOL, or ~$28k at the current market price of $21.31. This would prevent users from creating new markets.

However, a thought occurs to me - a change in MarketIndex to a u32 would markedly elevate this cost to $1.8B. Alternatively, we could consider a shift to a u64, which would result in a staggering cost of $7e18.