### PR TITLE
Process event on place order if remaining acc matches

### DIFF
--- a/programs/openbook-v2/src/instructions/consume_events.rs
+++ b/programs/openbook-v2/src/instructions/consume_events.rs
@@ -5,7 +5,6 @@ use crate::error::OpenBookError;
 use crate::state::*;
 
 use crate::accounts_ix::*;
-use crate::logs::FillLog;
 
 // Max events to consume per ix.
 const MAX_EVENTS_CONSUME: usize = 8;
@@ -67,23 +66,6 @@ pub fn consume_events(ctx: Context<ConsumeEvents>, limit: usize) -> Result<()> {
 
                 load_open_orders_acc!(maker, fill.maker, remaining_accs, event_queue);
                 maker.execute_maker(&mut market, fill)?;
-
-                emit!(FillLog {
-                    taker_side: fill.taker_side,
-                    maker_slot: fill.maker_slot,
-                    maker_out: fill.maker_out(),
-                    timestamp: fill.timestamp,
-                    seq_num: fill.seq_num,
-                    maker: fill.maker,
-                    maker_client_order_id: fill.maker_client_order_id,
-                    maker_fee: market.maker_fee.to_num(),
-                    maker_timestamp: fill.maker_timestamp,
-                    taker: fill.taker,
-                    taker_client_order_id: fill.taker_client_order_id,
-                    taker_fee: market.taker_fee.to_num(),
-                    price: fill.price,
-                    quantity: fill.quantity,
-                });
             }
             EventType::Out => {
                 let out: &OutEvent = cast_ref(event);

--- a/programs/openbook-v2/src/instructions/place_order.rs
+++ b/programs/openbook-v2/src/instructions/place_order.rs
@@ -79,11 +79,6 @@ pub fn place_order(ctx: Context<PlaceOrder>, order: Order, limit: u8) -> Result<
             };
 
             let free_qty_to_lock = cmp::min(max_quote_including_fees, free_quote);
-            msg!(
-                "to deposit max_quote_including_fees {}, free_quote {}",
-                max_quote_including_fees,
-                free_quote
-            );
             position.quote_free_native -= free_qty_to_lock;
 
             // Update market deposit total

--- a/programs/openbook-v2/src/instructions/place_order.rs
+++ b/programs/openbook-v2/src/instructions/place_order.rs
@@ -47,7 +47,6 @@ pub fn place_order(ctx: Context<PlaceOrder>, order: Order, limit: u8) -> Result<
         maker_fees,
         ..
     } = book.new_order(
-        ctx.remaining_accounts,
         &order,
         &mut market,
         &mut event_queue,
@@ -56,6 +55,7 @@ pub fn place_order(ctx: Context<PlaceOrder>, order: Order, limit: u8) -> Result<
         &open_orders_account_pk,
         now_ts,
         limit,
+        ctx.remaining_accounts,
     )?;
 
     let position = &mut open_orders_account.fixed_mut().position;

--- a/programs/openbook-v2/src/instructions/place_order.rs
+++ b/programs/openbook-v2/src/instructions/place_order.rs
@@ -47,6 +47,7 @@ pub fn place_order(ctx: Context<PlaceOrder>, order: Order, limit: u8) -> Result<
         maker_fees,
         ..
     } = book.new_order(
+        ctx.remaining_accounts,
         &order,
         &mut market,
         &mut event_queue,

--- a/programs/openbook-v2/src/instructions/place_take_order.rs
+++ b/programs/openbook-v2/src/instructions/place_take_order.rs
@@ -39,6 +39,7 @@ pub fn place_take_order<'info>(
         referrer_amount,
         ..
     } = book.new_order(
+        ctx.remaining_accounts,
         &order,
         &mut market,
         &mut event_queue,

--- a/programs/openbook-v2/src/instructions/place_take_order.rs
+++ b/programs/openbook-v2/src/instructions/place_take_order.rs
@@ -39,7 +39,6 @@ pub fn place_take_order<'info>(
         referrer_amount,
         ..
     } = book.new_order(
-        ctx.remaining_accounts,
         &order,
         &mut market,
         &mut event_queue,
@@ -48,6 +47,7 @@ pub fn place_take_order<'info>(
         &ctx.accounts.owner.key(),
         now_ts,
         limit,
+        ctx.remaining_accounts,
     )?;
 
     let (from_vault, to_vault, deposit_amount, withdraw_amount) = match side {

--- a/programs/openbook-v2/src/state/open_orders_account.rs
+++ b/programs/openbook-v2/src/state/open_orders_account.rs
@@ -11,6 +11,7 @@ use solana_program::program_memory::sol_memmove;
 use static_assertions::const_assert_eq;
 
 use crate::error::*;
+use crate::logs::FillLog;
 
 use super::FillEvent;
 use super::LeafNode;
@@ -432,6 +433,23 @@ impl<
         // Update market fees
         market.fees_accrued += market.maker_fee * quote_native.abs();
 
+        //Emit event
+        emit!(FillLog {
+            taker_side: fill.taker_side,
+            maker_slot: fill.maker_slot,
+            maker_out: fill.maker_out(),
+            timestamp: fill.timestamp,
+            seq_num: fill.seq_num,
+            maker: fill.maker,
+            maker_client_order_id: fill.maker_client_order_id,
+            maker_fee: market.maker_fee.to_num(),
+            maker_timestamp: fill.maker_timestamp,
+            taker: fill.taker,
+            taker_client_order_id: fill.taker_client_order_id,
+            taker_fee: market.taker_fee.to_num(),
+            price: fill.price,
+            quantity: fill.quantity,
+        });
         Ok(())
     }
 

--- a/programs/openbook-v2/src/state/orderbook/book.rs
+++ b/programs/openbook-v2/src/state/orderbook/book.rs
@@ -1,4 +1,3 @@
-use crate::logs::FillLog;
 use crate::state::open_orders_account::OpenOrdersLoader;
 use crate::state::OpenOrdersAccountRefMut;
 use crate::{
@@ -489,22 +488,6 @@ pub fn process_fill_event(
         let mut maker = ooa.load_full_mut()?;
 
         maker.execute_maker(market, &event)?;
-        emit!(FillLog {
-            taker_side: event.taker_side,
-            maker_slot: event.maker_slot,
-            maker_out: event.maker_out(),
-            timestamp: event.timestamp,
-            seq_num: event.seq_num,
-            maker: event.maker,
-            maker_client_order_id: event.maker_client_order_id,
-            maker_fee: market.maker_fee.to_num(),
-            maker_timestamp: event.maker_timestamp,
-            taker: event.taker,
-            taker_client_order_id: event.taker_client_order_id,
-            taker_fee: market.taker_fee.to_num(),
-            price: event.price,
-            quantity: event.quantity,
-        });
     } else {
         event_queue.push_back(cast(event)).unwrap();
     }

--- a/programs/openbook-v2/src/state/orderbook/book.rs
+++ b/programs/openbook-v2/src/state/orderbook/book.rs
@@ -115,18 +115,21 @@ impl<'a> Orderbook<'a> {
                         best_opposing.node.owner,
                         best_opposing.node.quantity,
                     );
+
                     // Check if remaining is available so no event is pushed to event_queue
                     let loader = remaining_accs.iter().find(|ai| ai.key == &event.owner);
                     if let Some(acc) = loader {
+                        msg!("then");
+
                         let ooa: AccountLoader<OpenOrdersAccountFixed> =
                             AccountLoader::try_from(acc)?;
                         let mut owner = ooa.load_full_mut()?;
                         owner.cancel_order(event.owner_slot as usize, event.quantity, *market)?;
                     } else {
                         event_queue.push_back(cast(event)).unwrap();
-                        matched_order_deletes
-                            .push((best_opposing.handle.order_tree, best_opposing.node.key));
                     }
+                    matched_order_deletes
+                        .push((best_opposing.handle.order_tree, best_opposing.node.key));
                 }
                 continue;
             }
@@ -241,8 +244,8 @@ impl<'a> Orderbook<'a> {
                 });
             } else {
                 event_queue.push_back(cast(fill)).unwrap();
-                limit -= 1;
             }
+            limit -= 1;
 
             if let Some(open_orders_acc) = open_orders_acc.as_mut() {
                 open_orders_acc.execute_taker(market, &fill)?

--- a/programs/openbook-v2/src/state/orderbook/book.rs
+++ b/programs/openbook-v2/src/state/orderbook/book.rs
@@ -1,4 +1,5 @@
 use crate::logs::FillLog;
+use crate::state::open_orders_account::OpenOrdersLoader;
 use crate::state::OpenOrdersAccountRefMut;
 use crate::{
     error::*,
@@ -203,35 +204,31 @@ impl<'a> Orderbook<'a> {
                 match_base_lots,
             );
 
-            if remaining_accs.len() > 0 {
-                let loader = remaining_accs.iter().find(|ai| ai.key == &fill.maker);
+            let loader = remaining_accs.iter().find(|ai| ai.key == &fill.maker);
+            if let Some(acc) = loader {
+                let mal: AccountLoader<OpenOrdersAccountFixed> = AccountLoader::try_from(acc)?;
+                let mut maker = mal.load_full_mut()?;
 
-                if let Some(acc) = loader {
-                    let mal: AccountLoader<OpenOrdersAccountFixed> = AccountLoader::try_from(acc)?;
-
-                    let mut maker = acc.load_full_mut()?;
-
-                    maker.execute_maker(market, fill)?;
-                    emit!(FillLog {
-                        taker_side: fill.taker_side,
-                        maker_slot: fill.maker_slot,
-                        maker_out: fill.maker_out(),
-                        timestamp: fill.timestamp,
-                        seq_num: fill.seq_num,
-                        maker: fill.maker,
-                        maker_client_order_id: fill.maker_client_order_id,
-                        maker_fee: market.maker_fee.to_num(),
-                        maker_timestamp: fill.maker_timestamp,
-                        taker: fill.taker,
-                        taker_client_order_id: fill.taker_client_order_id,
-                        taker_fee: market.taker_fee.to_num(),
-                        price: fill.price,
-                        quantity: fill.quantity,
-                    });
-                } else {
-                    event_queue.push_back(cast(fill)).unwrap();
-                    limit -= 1;
-                }
+                maker.execute_maker(market, &fill)?;
+                emit!(FillLog {
+                    taker_side: fill.taker_side,
+                    maker_slot: fill.maker_slot,
+                    maker_out: fill.maker_out(),
+                    timestamp: fill.timestamp,
+                    seq_num: fill.seq_num,
+                    maker: fill.maker,
+                    maker_client_order_id: fill.maker_client_order_id,
+                    maker_fee: market.maker_fee.to_num(),
+                    maker_timestamp: fill.maker_timestamp,
+                    taker: fill.taker,
+                    taker_client_order_id: fill.taker_client_order_id,
+                    taker_fee: market.taker_fee.to_num(),
+                    price: fill.price,
+                    quantity: fill.quantity,
+                });
+            } else {
+                event_queue.push_back(cast(fill)).unwrap();
+                limit -= 1;
             }
 
             if let Some(open_orders_acc) = open_orders_acc.as_mut() {

--- a/programs/openbook-v2/tests/cases/mod.rs
+++ b/programs/openbook-v2/tests/cases/mod.rs
@@ -16,5 +16,6 @@ mod test;
 mod test_fees;
 mod test_oracle_peg;
 mod test_order_types;
+mod test_place_order_remaining;
 mod test_self_trade;
 mod test_take_order;

--- a/programs/openbook-v2/tests/cases/test.rs
+++ b/programs/openbook-v2/tests/cases/test.rs
@@ -113,6 +113,7 @@ async fn test_simple_settle() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -136,6 +137,7 @@ async fn test_simple_settle() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -332,6 +334,7 @@ async fn test_cancel_orders() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -355,6 +358,7 @@ async fn test_cancel_orders() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -448,6 +452,7 @@ async fn test_cancel_orders() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -545,6 +550,7 @@ async fn test_cancel_orders() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -669,6 +675,7 @@ async fn test_expired_orders() -> Result<(), TransportError> {
             expiry_timestamp: now_ts + 2,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -704,6 +711,7 @@ async fn test_expired_orders() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await

--- a/programs/openbook-v2/tests/cases/test_fees.rs
+++ b/programs/openbook-v2/tests/cases/test_fees.rs
@@ -80,6 +80,7 @@ async fn test_fees_acrued() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -102,6 +103,7 @@ async fn test_fees_acrued() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -274,6 +276,7 @@ async fn test_maker_fees() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -320,6 +323,7 @@ async fn test_maker_fees() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -351,6 +355,7 @@ async fn test_maker_fees() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await

--- a/programs/openbook-v2/tests/cases/test_oracle_peg.rs
+++ b/programs/openbook-v2/tests/cases/test_oracle_peg.rs
@@ -137,6 +137,7 @@ async fn test_oracle_peg() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -212,6 +213,7 @@ async fn test_oracle_peg() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -248,6 +250,7 @@ async fn test_oracle_peg() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -307,6 +310,7 @@ async fn test_oracle_peg() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -343,6 +347,7 @@ async fn test_oracle_peg() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await

--- a/programs/openbook-v2/tests/cases/test_order_types.rs
+++ b/programs/openbook-v2/tests/cases/test_order_types.rs
@@ -81,6 +81,7 @@ async fn test_inmediate_order() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -107,6 +108,7 @@ async fn test_inmediate_order() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::ImmediateOrCancel,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -204,6 +206,7 @@ async fn test_inmediate_order() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -231,6 +234,7 @@ async fn test_inmediate_order() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::PostOnly,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -276,6 +280,7 @@ async fn test_inmediate_order() -> Result<(), TransportError> {
     //         client_order_id: 0,
     //         expiry_timestamp: 0,
     //         order_type: PlaceOrderType::PostOnly,
+    // remainings:vec![],
     //     },
     // )
     // .await
@@ -321,6 +326,7 @@ async fn test_inmediate_order() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::PostOnlySlide,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await

--- a/programs/openbook-v2/tests/cases/test_self_trade.rs
+++ b/programs/openbook-v2/tests/cases/test_self_trade.rs
@@ -387,8 +387,8 @@ async fn test_self_trade_cancel_provide() -> Result<(), TransportError> {
         let open_orders_account_1 = solana.get_account::<OpenOrdersAccount>(account_1).await;
 
         assert_eq!(open_orders_account_0.position.bids_base_lots, 0);
-        assert_eq!(open_orders_account_0.position.asks_base_lots, 1);
-        assert_eq!(open_orders_account_0.position.base_free_native, 100);
+        assert_eq!(open_orders_account_0.position.asks_base_lots, 0);
+        assert_eq!(open_orders_account_0.position.base_free_native, 200);
         assert_eq!(open_orders_account_0.position.quote_free_native, 0);
 
         assert_eq!(open_orders_account_1.position.bids_base_lots, 0);
@@ -426,8 +426,8 @@ async fn test_self_trade_cancel_provide() -> Result<(), TransportError> {
         let open_orders_account_1 = solana.get_account::<OpenOrdersAccount>(account_1).await;
 
         assert_eq!(open_orders_account_0.position.bids_base_lots, 0);
-        assert_eq!(open_orders_account_0.position.asks_base_lots, 1);
-        assert_eq!(open_orders_account_0.position.base_free_native, 200);
+        assert_eq!(open_orders_account_0.position.asks_base_lots, 0);
+        assert_eq!(open_orders_account_0.position.base_free_native, 300);
         assert_eq!(open_orders_account_0.position.quote_free_native, 0);
 
         assert_eq!(open_orders_account_1.position.bids_base_lots, 0);

--- a/programs/openbook-v2/tests/cases/test_self_trade.rs
+++ b/programs/openbook-v2/tests/cases/test_self_trade.rs
@@ -75,6 +75,7 @@ async fn test_self_trade_decrement_take() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -98,6 +99,7 @@ async fn test_self_trade_decrement_take() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -121,6 +123,7 @@ async fn test_self_trade_decrement_take() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::ImmediateOrCancel,
             self_trade_behavior: SelfTradeBehavior::DecrementTake,
+            remainings: vec![],
         },
     )
     .await
@@ -183,6 +186,7 @@ async fn test_self_trade_decrement_take() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::DecrementTake,
+            remainings: vec![],
         },
     )
     .await
@@ -309,6 +313,7 @@ async fn test_self_trade_cancel_provide() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -332,6 +337,7 @@ async fn test_self_trade_cancel_provide() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -370,6 +376,7 @@ async fn test_self_trade_cancel_provide() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::ImmediateOrCancel,
             self_trade_behavior: SelfTradeBehavior::CancelProvide,
+            remainings: vec![],
         },
     )
     .await
@@ -408,6 +415,7 @@ async fn test_self_trade_cancel_provide() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::DecrementTake,
+            remainings: vec![],
         },
     )
     .await
@@ -530,6 +538,7 @@ async fn test_self_abort_transaction() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -553,6 +562,7 @@ async fn test_self_abort_transaction() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::AbortTransaction,
+            remainings: vec![],
         },
     )
     .await

--- a/programs/openbook-v2/tests/cases/test_take_order.rs
+++ b/programs/openbook-v2/tests/cases/test_take_order.rs
@@ -81,6 +81,7 @@ async fn test_take_ask_order() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await
@@ -266,6 +267,7 @@ async fn test_take_bid_order() -> Result<(), TransportError> {
             expiry_timestamp: 0,
             order_type: PlaceOrderType::Limit,
             self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
         },
     )
     .await

--- a/programs/openbook-v2/tests/program_test/client.rs
+++ b/programs/openbook-v2/tests/program_test/client.rs
@@ -327,7 +327,9 @@ pub struct PlaceOrderInstruction {
     pub expiry_timestamp: u64,
     pub order_type: PlaceOrderType,
     pub self_trade_behavior: SelfTradeBehavior,
+    pub remainings: Vec<Pubkey>,
 }
+
 #[async_trait::async_trait(?Send)]
 impl ClientInstruction for PlaceOrderInstruction {
     type Accounts = openbook_v2::accounts::PlaceOrder;
@@ -365,8 +367,16 @@ impl ClientInstruction for PlaceOrderInstruction {
             token_program: Token::id(),
             system_program: System::id(),
         };
-        let instruction = make_instruction(program_id, &accounts, instruction);
-
+        let mut instruction = make_instruction(program_id, &accounts, instruction);
+        let mut vec_remainings: Vec<AccountMeta> = Vec::new();
+        for remaining in &self.remainings {
+            vec_remainings.push(AccountMeta {
+                pubkey: *remaining,
+                is_signer: false,
+                is_writable: true,
+            })
+        }
+        instruction.accounts.append(&mut vec_remainings);
         (accounts, instruction)
     }
 


### PR DESCRIPTION
In this way, no event is emitted to the event_queue and therefore the system is crankless as long as the maker is known when placing the order.