### PR TITLE
create market pass admin as accounts

### DIFF
--- a/programs/openbook-v2/src/accounts_ix/create_market.rs
+++ b/programs/openbook-v2/src/accounts_ix/create_market.rs
@@ -37,4 +37,13 @@ pub struct CreateMarket<'info> {
     pub system_program: Program<'info, System>,
     /// CHECK: The oracle can be one of several different account types and the pubkey is checked above
     pub oracle: UncheckedAccount<'info>,
+
+    /// CHECK:
+    pub collect_fee_admin: UncheckedAccount<'info>,
+    /// CHECK:
+    pub open_orders_admin: Option<UncheckedAccount<'info>>,
+    /// CHECK:
+    pub consume_events_admin: Option<UncheckedAccount<'info>>,
+    /// CHECK:
+    pub close_market_admin: Option<UncheckedAccount<'info>>,
 }

--- a/programs/openbook-v2/src/instructions/create_market.rs
+++ b/programs/openbook-v2/src/instructions/create_market.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use fixed::types::I80F48;
 
 use crate::error::*;
+use crate::pod_option::PodOption;
 use crate::state::*;
 use crate::util::fill_from_str;
 
@@ -19,10 +20,6 @@ pub fn create_market(
     maker_fee: f32,
     taker_fee: f32,
     fee_penalty: u64,
-    collect_fee_admin: Pubkey,
-    open_orders_admin: Option<Pubkey>,
-    consume_events_admin: Option<Pubkey>,
-    close_market_admin: Option<Pubkey>,
 ) -> Result<()> {
     let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
 
@@ -32,12 +29,33 @@ pub fn create_market(
         OpenBookError::InvalidFeesError
     );
 
+    let open_orders_admin: PodOption<Pubkey> = ctx
+        .accounts
+        .open_orders_admin
+        .as_ref()
+        .map(|account| account.key())
+        .into();
+
+    let consume_events_admin: PodOption<Pubkey> = ctx
+        .accounts
+        .consume_events_admin
+        .as_ref()
+        .map(|account| account.key())
+        .into();
+
+    let close_market_admin: PodOption<Pubkey> = ctx
+        .accounts
+        .close_market_admin
+        .as_ref()
+        .map(|account| account.key())
+        .into();
+
     let mut openbook_market = ctx.accounts.market.load_init()?;
     *openbook_market = Market {
-        collect_fee_admin,
-        open_orders_admin: open_orders_admin.into(),
-        consume_events_admin: consume_events_admin.into(),
-        close_market_admin: close_market_admin.into(),
+        collect_fee_admin: ctx.accounts.collect_fee_admin.key(),
+        open_orders_admin,
+        consume_events_admin,
+        close_market_admin,
         market_index,
         bump: *ctx.bumps.get("market").ok_or(OpenBookError::SomeError)?,
         base_decimals: ctx.accounts.base_mint.decimals,

--- a/programs/openbook-v2/src/lib.rs
+++ b/programs/openbook-v2/src/lib.rs
@@ -44,10 +44,6 @@ pub mod openbook_v2 {
         maker_fee: f32,
         taker_fee: f32,
         fee_penalty: u64,
-        collect_fee_admin: Pubkey,
-        open_orders_admin: Option<Pubkey>,
-        consume_events_admin: Option<Pubkey>,
-        close_market_admin: Option<Pubkey>,
     ) -> Result<()> {
         #[cfg(feature = "enable-gpl")]
         instructions::create_market(
@@ -60,10 +56,6 @@ pub mod openbook_v2 {
             maker_fee,
             taker_fee,
             fee_penalty,
-            collect_fee_admin,
-            open_orders_admin,
-            consume_events_admin,
-            close_market_admin,
         )?;
         Ok(())
     }

--- a/programs/openbook-v2/tests/program_test/client.rs
+++ b/programs/openbook-v2/tests/program_test/client.rs
@@ -259,10 +259,6 @@ impl ClientInstruction for CreateMarketInstruction {
     ) -> (Self::Accounts, instruction::Instruction) {
         let program_id = openbook_v2::id();
         let instruction = Self::Instruction {
-            collect_fee_admin: self.collect_fee_admin,
-            open_orders_admin: self.open_orders_admin,
-            consume_events_admin: self.consume_events_admin,
-            close_market_admin: self.close_market_admin,
             name: "ONE-TWO".to_string(),
             market_index: self.market_index,
             oracle_config: OracleConfigParams {
@@ -299,6 +295,10 @@ impl ClientInstruction for CreateMarketInstruction {
             quote_mint: self.quote_mint,
             base_mint: self.base_mint,
             system_program: System::id(),
+            collect_fee_admin: self.collect_fee_admin,
+            open_orders_admin: self.open_orders_admin,
+            consume_events_admin: self.consume_events_admin,
+            close_market_admin: self.close_market_admin,
         };
 
         let instruction = make_instruction(program_id, &accounts, instruction);


### PR DESCRIPTION
fuzzing the input arguments require that the types implements `Arbitrary`, which `pubkey` doesn't.
Move the market admin accs to the accounts context to be able to derive arbitrary trait