### PR TITLE
Add `test-dev` to `justfile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,10 @@ To drill down on a specific test (e.g., test_expired_order), run:
 ```bash
 just test test_expired_order
 ```
+
+If you want to have tests that automatically re-run when you edit a file, install
+[entr](https://github.com/eradman/entr) and run:
+
+```bash
+just test-dev
+```

--- a/justfile
+++ b/justfile
@@ -10,6 +10,9 @@ test TEST_NAME:
 test-all:
     (cd ./programs/openbook-v2 && RUST_LOG=ERROR cargo test-sbf --features enable-gpl)
 
+test-dev:
+    (find programs) | entr -s 'just test-all'
+
 idl:
     anchor build --arch sbf -- --features enable-gpl
     bash {{ justfile_directory() }}/idl-fixup.sh


### PR DESCRIPTION
I found that this helped with my dev workflow. I would run `(find programs) | entr -s 'just test-all'` in one terminal and edit files in another terminal, and my changes would be immediately tested to see if I introduced any bugs. A matter of preference though :shrug: