### PR TITLE
changes to make openbook-v2 compatible with mango-v4 0.19

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "3rdparty/fixed"]
-	path = 3rdparty/fixed
-	url = https://gitlab.com/ckamm/fixed.git
 [submodule "3rdparty/anchor"]
 	path = 3rdparty/anchor
 	url = https://github.com/openbook-dex/anchor.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,22 +113,11 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faa5be5b72abea167f87c868379ba3c2be356bfca9e6f474fd055fa0f7eeb4f2"
 dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-syn",
  "anyhow",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "regex",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-access-control"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -138,7 +127,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f468970344c7c9f9d03b4da854fd7c54f21305059f53789d0045c1dd803f0018"
 dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-syn",
  "anyhow",
  "bs58 0.5.0",
  "proc-macro2 1.0.67",
@@ -148,35 +137,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-attribute-account"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "bs58 0.5.0",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "anchor-attribute-constant"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59948e7f9ef8144c2aefb3f32a40c5fce2798baeec765ba038389e82301017ef"
 dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-syn",
  "proc-macro2 1.0.67",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-constant"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -186,18 +153,8 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc753c9d1c7981cb8948cf7e162fb0f64558999c0413058e2d43df1df5448086"
 dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-syn",
  "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-error"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -208,19 +165,8 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38b4e172ba1b52078f53fdc9f11e3dc0668ad27997838a0aad2d148afac8c97"
 dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-event"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -232,19 +178,9 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eebd21543606ab61e2d83d9da37d24d3886a49f390f9c43a1964735e8c0f0d5"
 dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-syn",
  "anyhow",
  "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-program"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -255,25 +191,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8434a6bf33efba0c93157f7fa2fafac658cb26ab75396886dcedd87c2a8ad445"
 dependencies = [
- "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anyhow",
- "futures 0.3.28",
- "regex",
- "serde",
- "solana-account-decoder",
- "solana-client",
- "solana-sdk",
- "thiserror",
- "tokio",
- "url 2.4.1",
-]
-
-[[package]]
-name = "anchor-client"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-lang",
  "anyhow",
  "futures 0.3.28",
  "regex",
@@ -292,30 +210,8 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4720d899b3686396cced9508f23dab420f1308344456ec78ef76f98fda42af"
 dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-derive-accounts"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-derive-serde"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "borsh-derive-internal 0.10.3",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -333,53 +229,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-derive-space"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "anchor-lang"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d2d4b20100f1310a774aba3471ef268e5c4ba4d5c28c0bbe663c2658acbc414"
 dependencies = [
- "anchor-attribute-access-control 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-attribute-account 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-attribute-constant 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-attribute-error 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-attribute-event 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-attribute-program 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-derive-accounts 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-derive-space 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayref",
- "base64 0.13.1",
- "bincode",
- "borsh 0.10.3",
- "bytemuck",
- "getrandom 0.2.10",
- "solana-program",
- "thiserror",
-]
-
-[[package]]
-name = "anchor-lang"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-attribute-access-control 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-attribute-account 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-attribute-constant 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-attribute-error 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-attribute-event 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-attribute-program 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-derive-accounts 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-derive-serde",
- "anchor-derive-space 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-access-control",
+ "anchor-attribute-account",
+ "anchor-attribute-constant",
+ "anchor-attribute-error",
+ "anchor-attribute-event",
+ "anchor-attribute-program",
+ "anchor-derive-accounts",
+ "anchor-derive-space",
  "arrayref",
  "base64 0.13.1",
  "bincode",
@@ -396,19 +258,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78f860599da1c2354e7234c768783049eb42e2f54509ecfc942d2e0076a2da7b"
 dependencies = [
- "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-program",
- "spl-associated-token-account 1.1.3",
- "spl-token 3.5.0",
- "spl-token-2022 0.6.1",
-]
-
-[[package]]
-name = "anchor-spl"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
-dependencies = [
- "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-lang",
  "solana-program",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
@@ -420,23 +270,6 @@ name = "anchor-syn"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a125e4b0cc046cfec58f5aa25038e34cf440151d58f0db3afc55308251fe936d"
-dependencies = [
- "anyhow",
- "bs58 0.5.0",
- "heck 0.3.3",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "serde",
- "serde_json",
- "sha2 0.10.7",
- "syn 1.0.109",
- "thiserror",
-]
-
-[[package]]
-name = "anchor-syn"
-version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
 dependencies = [
  "anyhow",
  "bs58 0.5.0",
@@ -3717,8 +3550,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "openbook-v2"
 version = "0.1.0"
 dependencies = [
- "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-spl 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-lang",
+ "anchor-spl",
  "arbitrary",
  "arrayref",
  "async-trait",
@@ -3750,9 +3583,9 @@ dependencies = [
 name = "openbook-v2-client"
 version = "0.3.0"
 dependencies = [
- "anchor-client 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-spl 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-client",
+ "anchor-lang",
+ "anchor-spl",
  "anyhow",
  "async-channel",
  "async-once-cell",
@@ -4587,8 +4420,8 @@ name = "raydium-amm-v3"
 version = "0.1.0"
 source = "git+https://github.com/raydium-io/raydium-clmm.git#6e4639f7133a8852068d2d473c263f907b69cd4a"
 dependencies = [
- "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang",
+ "anchor-spl",
  "arrayref",
  "bytemuck",
  "mpl-token-metadata",
@@ -7218,9 +7051,9 @@ version = "0.28.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a978513e0d3f54444698efb1737c8bcf366e2131e03ccfdf24c22210b8d755c"
 dependencies = [
- "anchor-client 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-client",
+ "anchor-lang",
+ "anchor-spl",
  "bincode",
  "bytemuck",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,23 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa5be5b72abea167f87c868379ba3c2be356bfca9e6f474fd055fa0f7eeb4f2"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "regex",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-access-control"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -121,9 +135,24 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f468970344c7c9f9d03b4da854fd7c54f21305059f53789d0045c1dd803f0018"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "bs58 0.5.0",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "rustversion",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-account"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "bs58 0.5.0",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -133,9 +162,20 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59948e7f9ef8144c2aefb3f32a40c5fce2798baeec765ba038389e82301017ef"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.67",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-constant"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -143,9 +183,21 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-error"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc753c9d1c7981cb8948cf7e162fb0f64558999c0413058e2d43df1df5448086"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-error"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -153,9 +205,22 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-event"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38b4e172ba1b52078f53fdc9f11e3dc0668ad27997838a0aad2d148afac8c97"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-event"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -164,9 +229,22 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-program"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eebd21543606ab61e2d83d9da37d24d3886a49f390f9c43a1964735e8c0f0d5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-program"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -174,9 +252,28 @@ dependencies = [
 [[package]]
 name = "anchor-client"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8434a6bf33efba0c93157f7fa2fafac658cb26ab75396886dcedd87c2a8ad445"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "futures 0.3.28",
+ "regex",
+ "serde",
+ "solana-account-decoder",
+ "solana-client",
+ "solana-sdk",
+ "thiserror",
+ "tokio",
+ "url 2.4.1",
+]
+
+[[package]]
+name = "anchor-client"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "anyhow",
  "futures 0.3.28",
  "regex",
@@ -192,9 +289,22 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec4720d899b3686396cced9508f23dab420f1308344456ec78ef76f98fda42af"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-accounts"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -202,9 +312,9 @@ dependencies = [
 [[package]]
 name = "anchor-derive-serde"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "borsh-derive-internal 0.10.3",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -214,7 +324,18 @@ dependencies = [
 [[package]]
 name = "anchor-derive-space"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f495e85480bd96ddeb77b71d499247c7d4e8b501e75ecb234e9ef7ae7bd6552a"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-space"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -224,17 +345,41 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d2d4b20100f1310a774aba3471ef268e5c4ba4d5c28c0bbe663c2658acbc414"
 dependencies = [
- "anchor-attribute-access-control",
- "anchor-attribute-account",
- "anchor-attribute-constant",
- "anchor-attribute-error",
- "anchor-attribute-event",
- "anchor-attribute-program",
- "anchor-derive-accounts",
+ "anchor-attribute-access-control 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-account 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-constant 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-error 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-event 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-program 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-derive-accounts 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-derive-space 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref",
+ "base64 0.13.1",
+ "bincode",
+ "borsh 0.10.3",
+ "bytemuck",
+ "getrandom 0.2.10",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-lang"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-attribute-access-control 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-account 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-constant 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-error 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-event 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-program 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-derive-accounts 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "anchor-derive-serde",
- "anchor-derive-space",
+ "anchor-derive-space 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "arrayref",
  "base64 0.13.1",
  "bincode",
@@ -248,9 +393,22 @@ dependencies = [
 [[package]]
 name = "anchor-spl"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f860599da1c2354e7234c768783049eb42e2f54509ecfc942d2e0076a2da7b"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
+ "spl-associated-token-account 1.1.3",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
+]
+
+[[package]]
+name = "anchor-spl"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "solana-program",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
@@ -260,7 +418,25 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.28.0"
-source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a125e4b0cc046cfec58f5aa25038e34cf440151d58f0db3afc55308251fe936d"
+dependencies = [
+ "anyhow",
+ "bs58 0.5.0",
+ "heck 0.3.3",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "serde",
+ "serde_json",
+ "sha2 0.10.7",
+ "syn 1.0.109",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-syn"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
 dependencies = [
  "anyhow",
  "bs58 0.5.0",
@@ -450,6 +626,12 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
@@ -469,7 +651,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror",
@@ -773,13 +955,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake3"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "199c42ab6972d92c9f8995f086273d25c42fc0f7b2a1fcefba465c1352d25ba5"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.4",
  "cc",
  "cfg-if 1.0.0",
  "constant_time_eq",
@@ -964,6 +1158,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecheck"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,7 +1268,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1280,6 +1496,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff76b51e4c068c52bfd2866e1567bee7c567ae8f24ada09fd4307019e25eab7"
+dependencies = [
+ "chrono",
+ "nom 7.1.3",
+ "once_cell",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,7 +1678,7 @@ checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint 0.4.4",
  "num-traits",
  "rusticata-macros",
@@ -1747,6 +1974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "envy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,6 +2134,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2209,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -2734,6 +2976,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec 0.5.2",
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3185,6 +3440,17 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check 0.9.4",
+]
+
+[[package]]
+name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -3353,7 +3619,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 
@@ -3451,8 +3717,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "openbook-v2"
 version = "0.1.0"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-spl 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "arbitrary",
  "arrayref",
  "async-trait",
@@ -3476,17 +3742,18 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
  "static_assertions",
+ "switchboard-common",
  "switchboard-program",
- "switchboard-v2",
+ "switchboard-solana",
 ]
 
 [[package]]
 name = "openbook-v2-client"
 version = "0.3.0"
 dependencies = [
- "anchor-client",
- "anchor-lang",
- "anchor-spl",
+ "anchor-client 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-spl 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "anyhow",
  "async-channel",
  "async-once-cell",
@@ -3552,9 +3819,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.4+3.1.2"
+version = "300.1.5+3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b6658b21fe1eba923af26cfe9c57a1a075a8190df2cd869a9bcd730093ffa2"
+checksum = "559068e4c12950d7dcaa1857a61725c0d38d4fc03ff8e070ab31a75d6e316491"
 dependencies = [
  "cc",
 ]
@@ -3988,6 +4255,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pyth-sdk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4103,6 +4390,12 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2 1.0.67",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4295,8 +4588,8 @@ name = "raydium-amm-v3"
 version = "0.1.0"
 source = "git+https://github.com/raydium-io/raydium-clmm.git#6e4639f7133a8852068d2d473c263f907b69cd4a"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayref",
  "bytemuck",
  "mpl-token-metadata",
@@ -4427,6 +4720,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "rend"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,6 +4788,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4540,20 +4870,25 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.26.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9164faf726e4f3ece4978b25ca877ddc6802fa77f38cdccb32c7f805ecd70c"
+checksum = "a4c4216490d5a413bc6d10fa4742bd7d4955941d062c0ef873141d6b0e7b30fd"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.4",
+ "borsh 0.10.3",
+ "bytes 1.5.0",
  "num-traits",
+ "rand 0.8.5",
+ "rkyv",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "rust_decimal_macros"
-version = "1.26.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903d8db81d2321699ca8318035d6ff805c548868df435813968795a802171b2"
+checksum = "86444b802de0b10ac5e563b5ddb43b541b9705de4e01a50e82194d2b183c1835"
 dependencies = [
  "quote 1.0.33",
  "rust_decimal",
@@ -4595,7 +4930,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -4741,6 +5076,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4880,6 +5221,15 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sgx-quote"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1640577af7b81d10db340c4b31006b77972e3918f351eec4e65c389c8b58e21"
+dependencies = [
+ "nom 5.1.3",
 ]
 
 [[package]]
@@ -5056,6 +5406,12 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simpl"
@@ -6815,6 +7171,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 
 [[package]]
+name = "switchboard-common"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9e28848b864786d8b1835f1f0c4c7e65190d9c17b246e5e21cc2457a70b176"
+dependencies = [
+ "envy",
+ "getrandom 0.2.10",
+ "hex",
+ "serde",
+ "serde_json",
+ "sgx-quote",
+ "sha2 0.10.7",
+]
+
+[[package]]
 name = "switchboard-program"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6843,6 +7214,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "switchboard-solana"
+version = "0.28.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a978513e0d3f54444698efb1737c8bcf366e2131e03ccfdf24c22210b8d755c"
+dependencies = [
+ "anchor-client 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode",
+ "bytemuck",
+ "chrono",
+ "cron",
+ "hex",
+ "rust_decimal",
+ "sgx-quote",
+ "solana-address-lookup-table-program",
+ "solana-client",
+ "solana-program",
+ "superslice",
+ "switchboard-common",
+ "tokio",
+ "url 2.4.1",
+]
+
+[[package]]
 name = "switchboard-utils"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6857,20 +7253,6 @@ dependencies = [
  "rust_decimal_macros",
  "solana-program",
  "switchboard-protos",
-]
-
-[[package]]
-name = "switchboard-v2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b81886169f446e22edc18ead7addd9ebd141c39bf2286cb37943c92cd3af724"
-dependencies = [
- "anchor-lang",
- "anchor-spl",
- "bytemuck",
- "rust_decimal",
- "solana-program",
- "superslice",
 ]
 
 [[package]]
@@ -6929,6 +7311,12 @@ dependencies = [
  "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -7621,9 +8009,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
@@ -7705,6 +8093,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "valuable"
@@ -8155,6 +8549,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8165,7 +8568,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,23 +110,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa5be5b72abea167f87c868379ba3c2be356bfca9e6f474fd055fa0f7eeb4f2"
-dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anyhow",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "regex",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-access-control"
-version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-syn",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -135,24 +121,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f468970344c7c9f9d03b4da854fd7c54f21305059f53789d0045c1dd803f0018"
-dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anyhow",
- "bs58 0.5.0",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-account"
-version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-syn",
  "bs58 0.5.0",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -162,32 +133,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59948e7f9ef8144c2aefb3f32a40c5fce2798baeec765ba038389e82301017ef"
-dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.67",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-constant"
-version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-error"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc753c9d1c7981cb8948cf7e162fb0f64558999c0413058e2d43df1df5448086"
-dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.67",
+ "anchor-syn",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -197,20 +145,7 @@ name = "anchor-attribute-error"
 version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-event"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38b4e172ba1b52078f53fdc9f11e3dc0668ad27997838a0aad2d148afac8c97"
-dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anyhow",
- "proc-macro2 1.0.67",
+ "anchor-syn",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -220,20 +155,7 @@ name = "anchor-attribute-event"
 version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-attribute-program"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eebd21543606ab61e2d83d9da37d24d3886a49f390f9c43a1964735e8c0f0d5"
-dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anyhow",
+ "anchor-syn",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -244,7 +166,7 @@ name = "anchor-attribute-program"
 version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-syn",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -254,7 +176,7 @@ name = "anchor-client"
 version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-lang",
  "anyhow",
  "futures 0.3.28",
  "regex",
@@ -270,22 +192,9 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4720d899b3686396cced9508f23dab420f1308344456ec78ef76f98fda42af"
-dependencies = [
- "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anyhow",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-derive-accounts"
-version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-syn",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -295,7 +204,7 @@ name = "anchor-derive-serde"
 version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-syn",
  "borsh-derive-internal 0.10.3",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -305,17 +214,6 @@ dependencies = [
 [[package]]
 name = "anchor-derive-space"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f495e85480bd96ddeb77b71d499247c7d4e8b501e75ecb234e9ef7ae7bd6552a"
-dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "anchor-derive-space"
-version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
  "proc-macro2 1.0.67",
@@ -326,41 +224,17 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d4b20100f1310a774aba3471ef268e5c4ba4d5c28c0bbe663c2658acbc414"
-dependencies = [
- "anchor-attribute-access-control 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-attribute-account 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-attribute-constant 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-attribute-error 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-attribute-event 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-attribute-program 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-derive-accounts 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-derive-space 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayref",
- "base64 0.13.1",
- "bincode",
- "borsh 0.10.3",
- "bytemuck",
- "getrandom 0.2.10",
- "solana-program",
- "thiserror",
-]
-
-[[package]]
-name = "anchor-lang"
-version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-attribute-access-control 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "anchor-attribute-account 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "anchor-attribute-constant 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "anchor-attribute-error 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "anchor-attribute-event 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "anchor-attribute-program 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "anchor-derive-accounts 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-access-control",
+ "anchor-attribute-account",
+ "anchor-attribute-constant",
+ "anchor-attribute-error",
+ "anchor-attribute-event",
+ "anchor-attribute-program",
+ "anchor-derive-accounts",
  "anchor-derive-serde",
- "anchor-derive-space 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-derive-space",
  "arrayref",
  "base64 0.13.1",
  "bincode",
@@ -374,44 +248,13 @@ dependencies = [
 [[package]]
 name = "anchor-spl"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f860599da1c2354e7234c768783049eb42e2f54509ecfc942d2e0076a2da7b"
-dependencies = [
- "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-program",
- "spl-associated-token-account 1.1.3",
- "spl-token 3.5.0",
- "spl-token-2022 0.6.1",
-]
-
-[[package]]
-name = "anchor-spl"
-version = "0.28.0"
 source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-lang",
  "solana-program",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.1",
-]
-
-[[package]]
-name = "anchor-syn"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a125e4b0cc046cfec58f5aa25038e34cf440151d58f0db3afc55308251fe936d"
-dependencies = [
- "anyhow",
- "bs58 0.5.0",
- "heck 0.3.3",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "serde",
- "serde_json",
- "sha2 0.10.7",
- "syn 1.0.109",
- "thiserror",
 ]
 
 [[package]]
@@ -3608,8 +3451,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "openbook-v2"
 version = "0.1.0"
 dependencies = [
- "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "anchor-spl 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-lang",
+ "anchor-spl",
  "arbitrary",
  "arrayref",
  "async-trait",
@@ -3642,8 +3485,8 @@ name = "openbook-v2-client"
 version = "0.3.0"
 dependencies = [
  "anchor-client",
- "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
- "anchor-spl 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-lang",
+ "anchor-spl",
  "anyhow",
  "async-channel",
  "async-once-cell",
@@ -4452,8 +4295,8 @@ name = "raydium-amm-v3"
 version = "0.1.0"
 source = "git+https://github.com/raydium-io/raydium-clmm.git#6e4639f7133a8852068d2d473c263f907b69cd4a"
 dependencies = [
- "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang",
+ "anchor-spl",
  "arrayref",
  "bytemuck",
  "mpl-token-metadata",
@@ -7022,8 +6865,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b81886169f446e22edc18ead7addd9ebd141c39bf2286cb37943c92cd3af724"
 dependencies = [
- "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang",
+ "anchor-spl",
  "bytemuck",
  "rust_decimal",
  "solana-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+checksum = "0f2135563fb5c609d2b2b87c1e8ce7bc41b0b45430fa9661f457981503dd5bf0"
 dependencies = [
  "memchr",
 ]
@@ -124,9 +124,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -150,9 +150,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "bs58 0.5.0",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -173,9 +173,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -195,9 +195,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-error"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -218,9 +218,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-event"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -242,9 +242,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-program"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -252,9 +252,9 @@ dependencies = [
 [[package]]
 name = "anchor-client"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "anyhow",
  "futures 0.3.28",
  "regex",
@@ -283,9 +283,9 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -293,9 +293,9 @@ dependencies = [
 [[package]]
 name = "anchor-derive-serde"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "borsh-derive-internal 0.10.3",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-space"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -350,17 +350,17 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-attribute-access-control 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-attribute-account 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-attribute-constant 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-attribute-error 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-attribute-event 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-attribute-program 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-derive-accounts 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-access-control 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-account 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-constant 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-error 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-event 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-program 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-derive-accounts 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "anchor-derive-serde",
- "anchor-derive-space 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-derive-space 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "arrayref",
  "base64 0.13.1",
  "bincode",
@@ -387,9 +387,9 @@ dependencies = [
 [[package]]
 name = "anchor-spl"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
- "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "solana-program",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.28.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
  "anyhow",
  "bs58 0.5.0",
@@ -721,7 +721,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -732,7 +732,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -905,7 +905,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bv"
@@ -1137,7 +1137,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1226,9 +1226,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1560,7 +1560,7 @@ dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "strsim 0.10.0",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1571,7 +1571,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1645,7 +1645,7 @@ checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1751,7 +1751,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "eager"
@@ -1874,7 +1874,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1887,7 +1887,7 @@ dependencies = [
  "num-traits",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2119,7 +2119,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3283,13 +3283,13 @@ dependencies = [
 
 [[package]]
 name = "mpl-utils"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfbd03696c53e72ae822e9ee8cae3e156031e30e9b4d5b3b33ae3990e79116f3"
+checksum = "3f2e4f92aec317d5853c0cc4c03c55f5178511c45bb3dbb441aea63117bf3dc9"
 dependencies = [
  "arrayref",
  "solana-program",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.6.1",
 ]
 
 [[package]]
@@ -3447,7 +3447,7 @@ checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3562,7 +3562,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3574,7 +3574,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3608,8 +3608,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "openbook-v2"
 version = "0.1.0"
 dependencies = [
- "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-spl 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-spl 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "arbitrary",
  "arrayref",
  "async-trait",
@@ -3621,7 +3621,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.20",
- "mpl-utils",
  "num 0.4.1",
  "num_enum 0.5.11",
  "pyth-sdk-solana",
@@ -3643,8 +3642,8 @@ name = "openbook-v2-client"
 version = "0.3.0"
 dependencies = [
  "anchor-client",
- "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
- "anchor-spl 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-spl 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "anyhow",
  "async-channel",
  "async-once-cell",
@@ -3699,7 +3698,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3710,9 +3709,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.3+3.1.2"
+version = "300.1.4+3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2c101a165fff9935e34def4669595ab1c7847943c42be86e21503e482be107"
+checksum = "80b6658b21fe1eba923af26cfe9c57a1a075a8190df2cd869a9bcd730093ffa2"
 dependencies = [
  "cc",
 ]
@@ -3939,7 +3938,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4018,7 +4017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2 1.0.67",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4451,7 +4450,7 @@ dependencies = [
 [[package]]
 name = "raydium-amm-v3"
 version = "0.1.0"
-source = "git+https://github.com/raydium-io/raydium-clmm.git#bcee27ac83feece4f1849f4ec1b57c7f2ea12770"
+source = "git+https://github.com/raydium-io/raydium-clmm.git#6e4639f7133a8852068d2d473c263f907b69cd4a"
 dependencies = [
  "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4840,9 +4839,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.13"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763f8cd0d4c71ed8389c90cb8100cba87e763bd01a8e614d4f0af97bcd50a161"
+checksum = "1f7b0ce13155372a76ee2e1c5ffba1fe61ede73fbea5630d61eee6fac4929c0c"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -4852,9 +4851,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.13"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f696e21e10fa546b7ffb1c9672c6de8fbc7a81acf59524386d8639bf12737"
+checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -4885,7 +4884,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4968,7 +4967,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5024,7 +5023,7 @@ dependencies = [
  "darling",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5644,7 +5643,7 @@ dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustc_version 0.4.0",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6323,7 +6322,7 @@ dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustversion",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6710,7 +6709,7 @@ checksum = "b4fa8f409b5c5e0ac571df17c981ae1424b204743daa4428430627d38717caf5"
 dependencies = [
  "quote 1.0.33",
  "spl-discriminator-syn",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6722,7 +6721,7 @@ dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "solana-program",
- "syn 2.0.33",
+ "syn 2.0.37",
  "thiserror",
 ]
 
@@ -6779,7 +6778,7 @@ dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
  "solana-program",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -7061,9 +7060,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.33"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -7149,9 +7148,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -7188,7 +7187,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -7621,7 +7620,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -7716,9 +7715,9 @@ checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uint"
@@ -7958,7 +7957,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -7992,7 +7991,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8365,7 +8364,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,11 +113,22 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faa5be5b72abea167f87c868379ba3c2be356bfca9e6f474fd055fa0f7eeb4f2"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "regex",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-access-control"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -127,12 +138,24 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f468970344c7c9f9d03b4da854fd7c54f21305059f53789d0045c1dd803f0018"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
  "bs58 0.5.0",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustversion",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-account"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "bs58 0.5.0",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -142,8 +165,18 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59948e7f9ef8144c2aefb3f32a40c5fce2798baeec765ba038389e82301017ef"
 dependencies = [
- "anchor-syn",
- "proc-macro2 1.0.66",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.67",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-constant"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -153,8 +186,18 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc753c9d1c7981cb8948cf7e162fb0f64558999c0413058e2d43df1df5448086"
 dependencies = [
- "anchor-syn",
- "proc-macro2 1.0.66",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-error"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -165,9 +208,20 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38b4e172ba1b52078f53fdc9f11e3dc0668ad27997838a0aad2d148afac8c97"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-event"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -178,9 +232,19 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eebd21543606ab61e2d83d9da37d24d3886a49f390f9c43a1964735e8c0f0d5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-program"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -188,10 +252,9 @@ dependencies = [
 [[package]]
 name = "anchor-client"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8434a6bf33efba0c93157f7fa2fafac658cb26ab75396886dcedd87c2a8ad445"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "anyhow",
  "futures 0.3.28",
  "regex",
@@ -210,9 +273,31 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4720d899b3686396cced9508f23dab420f1308344456ec78ef76f98fda42af"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-accounts"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-serde"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "borsh-derive-internal 0.10.3",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -223,7 +308,17 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f495e85480bd96ddeb77b71d499247c7d4e8b501e75ecb234e9ef7ae7bd6552a"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-space"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -234,14 +329,38 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d2d4b20100f1310a774aba3471ef268e5c4ba4d5c28c0bbe663c2658acbc414"
 dependencies = [
- "anchor-attribute-access-control",
- "anchor-attribute-account",
- "anchor-attribute-constant",
- "anchor-attribute-error",
- "anchor-attribute-event",
- "anchor-attribute-program",
- "anchor-derive-accounts",
- "anchor-derive-space",
+ "anchor-attribute-access-control 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-account 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-constant 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-error 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-event 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-program 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-derive-accounts 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-derive-space 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref",
+ "base64 0.13.1",
+ "bincode",
+ "borsh 0.10.3",
+ "bytemuck",
+ "getrandom 0.2.10",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-lang"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-attribute-access-control 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-account 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-constant 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-error 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-event 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-program 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-derive-accounts 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-derive-serde",
+ "anchor-derive-space 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "arrayref",
  "base64 0.13.1",
  "bincode",
@@ -258,11 +377,23 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78f860599da1c2354e7234c768783049eb42e2f54509ecfc942d2e0076a2da7b"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-program",
- "spl-associated-token-account",
- "spl-token",
- "spl-token-2022",
+ "spl-associated-token-account 1.1.3",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
+]
+
+[[package]]
+name = "anchor-spl"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "solana-program",
+ "spl-associated-token-account 1.1.3",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
 ]
 
 [[package]]
@@ -274,7 +405,24 @@ dependencies = [
  "anyhow",
  "bs58 0.5.0",
  "heck 0.3.3",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "serde",
+ "serde_json",
+ "sha2 0.10.7",
+ "syn 1.0.109",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-syn"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anyhow",
+ "bs58 0.5.0",
+ "heck 0.3.3",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "serde",
  "serde_json",
@@ -394,7 +542,7 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -430,7 +578,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -491,7 +639,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
  "synstructure",
@@ -503,7 +651,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -571,9 +719,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -582,9 +730,9 @@ version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -720,9 +868,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64ct"
@@ -751,13 +899,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.14",
- "proc-macro2 1.0.66",
+ "prettyplease 0.2.15",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -849,7 +997,7 @@ dependencies = [
  "borsh-derive-internal 0.9.3",
  "borsh-schema-derive-internal 0.9.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "syn 1.0.109",
 ]
 
@@ -862,7 +1010,7 @@ dependencies = [
  "borsh-derive-internal 0.10.3",
  "borsh-schema-derive-internal 0.10.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "syn 1.0.109",
 ]
 
@@ -872,7 +1020,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -883,7 +1031,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -894,7 +1042,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -905,7 +1053,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -987,9 +1135,9 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1409,10 +1557,10 @@ checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "strsim 0.10.0",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1423,7 +1571,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1484,7 +1632,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -1495,9 +1643,9 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1507,7 +1655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustc_version 0.4.0",
  "syn 1.0.109",
@@ -1601,9 +1749,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1678,12 +1826,12 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079044df30bb07de7d846d41a184c4b00e66ebdac93ee459253474f3a47e50ae"
+checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -1724,9 +1872,9 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1737,9 +1885,9 @@ checksum = "e4f76552f53cefc9a7f64987c3701b99d982f7690606fd67de1d09712fbf52f1"
 dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1824,13 +1972,12 @@ dependencies = [
 [[package]]
 name = "fixed"
 version = "1.11.0"
+source = "git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango#01516ae3e29418feb066b67830540aa81d04df05"
 dependencies = [
- "arbitrary",
  "az",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bytemuck",
  "half",
- "num-traits",
  "serde",
  "typenum",
 ]
@@ -1970,9 +2117,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -2175,7 +2322,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes 1.5.0",
  "headers-core",
  "http",
@@ -2637,7 +2784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -2745,9 +2892,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libloading"
@@ -2841,9 +2988,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
@@ -3070,7 +3217,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -3084,7 +3231,7 @@ dependencies = [
  "borsh 0.9.3",
  "bytemuck",
  "mpl-token-metadata-context-derive 0.2.1",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rmp-serde",
  "serde",
@@ -3105,12 +3252,12 @@ dependencies = [
  "mpl-token-auth-rules",
  "mpl-token-metadata-context-derive 0.3.0",
  "mpl-utils",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "shank",
  "solana-program",
- "spl-associated-token-account",
- "spl-token",
+ "spl-associated-token-account 2.1.0",
+ "spl-token 4.0.0",
  "thiserror",
 ]
 
@@ -3136,13 +3283,13 @@ dependencies = [
 
 [[package]]
 name = "mpl-utils"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2e4f92aec317d5853c0cc4c03c55f5178511c45bb3dbb441aea63117bf3dc9"
+checksum = "bfbd03696c53e72ae822e9ee8cae3e156031e30e9b4d5b3b33ae3990e79116f3"
 dependencies = [
  "arrayref",
  "solana-program",
- "spl-token-2022",
+ "spl-token-2022 0.8.0",
 ]
 
 [[package]]
@@ -3287,9 +3434,20 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -3375,13 +3533,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+dependencies = [
+ "num_enum_derive 0.7.0",
+]
+
+[[package]]
 name = "num_enum_derive"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -3393,9 +3560,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -3429,8 +3608,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "openbook-v2"
 version = "0.1.0"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-spl 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "arbitrary",
  "arrayref",
  "async-trait",
@@ -3442,6 +3621,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.20",
+ "mpl-utils",
  "num 0.4.1",
  "num_enum 0.5.11",
  "pyth-sdk-solana",
@@ -3451,8 +3631,8 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account",
- "spl-token",
+ "spl-associated-token-account 1.1.3",
+ "spl-token 3.5.0",
  "static_assertions",
  "switchboard-program",
  "switchboard-v2",
@@ -3463,8 +3643,8 @@ name = "openbook-v2-client"
 version = "0.3.0"
 dependencies = [
  "anchor-client",
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-spl 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "anyhow",
  "async-channel",
  "async-once-cell",
@@ -3490,7 +3670,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sdk",
- "spl-associated-token-account",
+ "spl-associated-token-account 1.1.3",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3517,9 +3697,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -3593,7 +3773,7 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -3757,9 +3937,9 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -3827,18 +4007,18 @@ version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8832c0f9be7e3cae60727e6256cfd2cd3c3e2b6cd5dad4190ecb2fd658c9030b"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
- "proc-macro2 1.0.66",
- "syn 2.0.31",
+ "proc-macro2 1.0.67",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -3867,7 +4047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
  "version_check 0.9.4",
@@ -3879,7 +4059,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "version_check 0.9.4",
 ]
@@ -3895,9 +4075,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -3942,7 +4122,7 @@ checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -3988,7 +4168,7 @@ dependencies = [
  "borsh 0.10.3",
  "borsh-derive 0.10.3",
  "bytemuck",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pyth-sdk",
  "serde",
@@ -4079,7 +4259,7 @@ version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
 ]
 
 [[package]]
@@ -4273,8 +4453,8 @@ name = "raydium-amm-v3"
 version = "0.1.0"
 source = "git+https://github.com/raydium-io/raydium-clmm.git#bcee27ac83feece4f1849f4ec1b57c7f2ea12770"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayref",
  "bytemuck",
  "mpl-token-metadata",
@@ -4411,7 +4591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
  "async-compression",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes 1.5.0",
  "encoding_rs",
  "futures-core",
@@ -4578,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.11"
+version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -4619,7 +4799,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
 ]
 
 [[package]]
@@ -4676,7 +4856,7 @@ version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0f696e21e10fa546b7ffb1c9672c6de8fbc7a81acf59524386d8639bf12737"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "serde_derive_internals",
  "syn 1.0.109",
@@ -4703,9 +4883,9 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -4786,9 +4966,9 @@ version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -4797,16 +4977,16 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -4842,9 +5022,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -4971,7 +5151,7 @@ version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63927d22a1e8b74bda98cc6e151fcdf178b7abb0dc6c4f81e0bbf5ffe2fc4ec8"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "shank_macro_impl",
  "syn 1.0.109",
@@ -4984,7 +5164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce03403df682f80f4dc1efafa87a4d0cb89b03726d0565e6364bdca5b9a441"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "serde",
  "syn 1.0.109",
@@ -5118,12 +5298,12 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e0074eb8b7115c7648de67d1dd1cc31505afcc9ebe16eb4ba3cff6f1520385"
+checksum = "b83daa56035885dac1a47f5bd3d4e02379e3fc5915b2c3ce978a9af9eeecf07d"
 dependencies = [
  "Inflector",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "bs58 0.4.0",
  "bv",
@@ -5134,22 +5314,22 @@ dependencies = [
  "solana-address-lookup-table-program",
  "solana-config-program",
  "solana-sdk",
- "spl-token",
- "spl-token-2022",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
  "thiserror",
  "zstd",
 ]
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85261ec5a2cee18d926e1c48265a760896fa06a6b431b3f1d43a8b0f7a3aa28d"
+checksum = "2dd3f3e85d67e559985fbdc6b5b4d5dd9c8462b78e6079c3b465496c1f3c55d6"
 dependencies = [
  "bincode",
  "bytemuck",
  "log 0.4.20",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
@@ -5163,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eeb343648da07e2bf62735f67d2b32a907b558d36dd9ba439a97c6f30f02b49"
+checksum = "e7703026aea6e6fc89cdd77e9d7e08e3890bdddc4177efbf971da75284a353c5"
 dependencies = [
  "borsh 0.10.3",
  "futures 0.3.28",
@@ -5180,9 +5360,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216d03001f7ab332ac4a38adfce664f8a9a2b70de924f004087b6629985c777"
+checksum = "2cea685028231e10a02c6f021ca6cd1d0446a7ecb199b8c9e939d5cccb57ec9d"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -5191,9 +5371,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e08584a28fafb5c8b06ef90cc9eba2315962094db7053de02bfc183dadb15f"
+checksum = "49a1c4d902adb2c19a65caf025307e76e6bae92415ed8adeb68aaf6b5034b2bc"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5210,9 +5390,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ecb58e7210be89d54fec5b43126c4ca7f9d67b91aa09d4beb35034b83b91d73"
+checksum = "c3f7ffadcb9166e792e9a9db018e14391692373c439da87a082f0652d28484e1"
 dependencies = [
  "bv",
  "fnv",
@@ -5229,9 +5409,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cd08c1708e67b916868d967c8b88aeeee042b13e3c694281e0b70a99eed71e"
+checksum = "3da230f2ff22007e2ca60507346488a65ec274fbb2486bdd2d10948eef2c03d8"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5248,9 +5428,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be4e8f905d14b4b6dd8430af81b56ebb964377615784f70f36cf6a70436c03a"
+checksum = "89e8716aa59039a8eeac13a5d090561ae11a252d674e9b41d97fe382a70545b9"
 dependencies = [
  "bv",
  "log 0.4.20",
@@ -5265,9 +5445,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae8384f3a2fa5f765de3f4c2d6dc2b26d4a6ac0b740f5318d17326158fa0c0a"
+checksum = "3669a399b8ef60642471e68e1f93d3f3050248a4fa1436341596cfcb2a484e8b"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -5283,9 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae44ab7fbb1b26df2bf71bdc3a0c1dc9aaabfa9ba1ecd9acb1f54614d01b86f"
+checksum = "79b593a0718a12d73fff3c5d9d405981c778a1806c66d327f5bdef0bec23402f"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5299,9 +5479,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84514073c108af24e0408e00d7e490e4f90e87c1a4ee4dcffa34b200d1da446b"
+checksum = "e96d8a28ca30cd385f7c2c4a7f93edc32c18bc041baa0e8b25bd56cd28c51cbb"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5332,9 +5512,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ee0c59cd7880b1c39878d18308d324450c4ee724f892d418d6891c18da142c"
+checksum = "552f79e747bd8bb7baa229007f5ff54971f67ec6f0f9d2a06a95adfaabe3f19c"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -5342,9 +5522,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2c6b161fc8e7bd86733559eaf6142f271dda233efd7fa1e2edacf98b4cc4cd"
+checksum = "0a35e4cc9f2996a2ef95aac398443fc4a110ef585521e11a7685b3591648b7cf"
 dependencies = [
  "bincode",
  "chrono",
@@ -5356,9 +5536,9 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1162b7d11807c5b5c77b2da3fbf9df7bd7fc71c9d6ecf3c13a5ff8541928a7b"
+checksum = "5ecb12464ee1322a02635345522839958d78a2bacff18298991cacf298178f64"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5377,9 +5557,9 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a62abf5174a33d9dd145875e63aefd9f15f2be23460f1e2cbab1f0a68b4562"
+checksum = "8b2d9d9d65da6ddd170ed35ff484e08a52ab30260e48602b02979d06afa69c6d"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5400,9 +5580,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a8dc5fa8c196606c28dcd133c80383bf292c88a3131671afa0e27a8e5c3721"
+checksum = "fa14ab9f44667719270dd174538d0c0fa869ddfb69a1b2ac1aa2d510e98da009"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5417,16 +5597,16 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-version",
- "spl-memo",
+ "spl-memo 3.0.1",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0447b0bb6ab6c6fc0e83bd106618c23d241c4fb8090de715a9811fb993fbfd07"
+checksum = "35b9e2169fd13394af838b13f047067c35ce69372aea0fb46e026405b5e931f9"
 dependencies = [
  "ahash 0.8.3",
  "blake3",
@@ -5457,21 +5637,21 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc86a118888cef8a3878f6dc9c291787cb21ef50cd98e7271f1e0ff548153b8"
+checksum = "db08ab0af4007dc0954b900aa5febc0c0ae50d9f9f598be27263c3195d90240b"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustc_version 0.4.0",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "solana-gossip"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240ec2b603768f03154edadcfa7d59569c0a79d7cb46cc522179fc47e77d2607"
+checksum = "3e92adeef5ae855ac396fddd062a89e61e135be82a64a700a9ec56510d3a3b6a"
 dependencies = [
  "bincode",
  "bv",
@@ -5517,9 +5697,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7b2e81be0195086116ad23bfde77bbed00e8e30e5c7c7095ecc9fa0cefdd6a"
+checksum = "a056ca06d1b224ddc933e81928cd3e0670ee81ad1c1a03641238384a597d1309"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5566,8 +5746,8 @@ dependencies = [
  "solana-storage-proto",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-token",
- "spl-token-2022",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
  "static_assertions",
  "tempfile",
  "thiserror",
@@ -5578,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7928dba97891bc52fe2a8d1e10db959029763dfb43e44519061df4fc91f9c514"
+checksum = "e84811758fce4dcfd9617a7c3178effe9e59480d43c1e862bb3c8daccfcfd61d"
 dependencies = [
  "log 0.4.20",
  "rand 0.7.3",
@@ -5592,9 +5772,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac77d7fc0144181d4f6c8eb4203bb5fe54d486fa19ccaab7615ccb4b874b0de"
+checksum = "bf8a48e734f78a44399516f7c130c114b455911e351f001abc0d96e7c5694efa"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5603,9 +5783,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441deecebeb23ff7da89df5db5ec712458903c7cc733c8ae1e0a26daf2c1130a"
+checksum = "d3529d2ff63ceedd3707c51188aacb9e3c142118de3f55447c40584a78223ffd"
 dependencies = [
  "log 0.4.20",
  "solana-sdk",
@@ -5613,9 +5793,9 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb7038d0e244de4defc41cede6f13ca0353e54edde3371ad314a662b4c8ef28"
+checksum = "d9b8f858f09ad792dbf397ad87e04f8e0ee57c1ce3521a65a5bcdb93ae57b0b6"
 dependencies = [
  "fast-math",
  "matches",
@@ -5624,9 +5804,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229583448485d731afb88e2bfd3a6b978312d4690c7452a35f8da47c02d4fd4f"
+checksum = "4792f29de5378a13c51be3fa9fdd526a20550b5ffabd7d1a57a4e49468e17d90"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -5638,9 +5818,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e246018a28e65d02d2b0e5141d3f89865a92e8b495a468a632b7028396626c"
+checksum = "7ed75beb465e211c79d31ae2049cb85974203e5ac21ae89396378d5a2fe71962"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -5660,9 +5840,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103fe87a578aa1771ee992e2654b2830ffc16709d429c3bb0d2c36ef8fee4d1d"
+checksum = "9218d9c823b22a465f91c966e8254a5f57b6817e0121ec6d4bf9a5ddc8307f18"
 dependencies = [
  "ahash 0.8.3",
  "bincode",
@@ -5687,9 +5867,9 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5e3d3539dc4a19dd399c7644a978c89a8b58d2de846fb83ad2fcc2de8fc38a"
+checksum = "cd1cf00275f3fc5f8520f432af8f1bf667d0f3580e012406a2134e5a67d58099"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -5705,16 +5885,16 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3841458623bd80b8291e8991f7353d674bb39656b1db83ec1aa5916a1b6ed7c"
+checksum = "2f17a1fbcf1e94e282db16153d323b446d6386ac99f597f78e76332265829336"
 dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
  "array-bytes",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "bitflags 1.3.2",
  "blake3",
@@ -5736,7 +5916,7 @@ dependencies = [
  "log 0.4.20",
  "memoffset 0.9.0",
  "num-bigint 0.4.4",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "parking_lot 0.12.1",
  "rand 0.7.3",
@@ -5760,18 +5940,18 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cc1b1f3a5a9f6735668a67e3d1fe161ec2d4931ef523acc4d716704b9fc11f"
+checksum = "2ff9f0c8043b2e7921e25a3fee88fa253b8cb5dbab1e521a4d83e78e8874c551"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "eager",
  "enum-iterator",
  "itertools",
  "libc",
  "log 0.4.20",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "percentage",
  "rand 0.7.3",
@@ -5788,13 +5968,13 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65bd59996bfd6e7f18ef5ccb69f8bb2f444bbcde390f7ad3c68269bace3501d"
+checksum = "ed844e7d13e497e86c853ad19181724119100818673df931f8404a3e280c1828"
 dependencies = [
  "assert_matches",
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "chrono-humanize",
  "crossbeam-channel",
@@ -5815,9 +5995,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df90f4a572b3d5d601ca6a8bde0d6024b45fc4204753b74a5156a538aac3b7c6"
+checksum = "6e0659db803f68fb440c87f43a603e2da7adb3dd11d68e119c3209ed3ca02073"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5840,9 +6020,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433148255e4f526a0bb50f3f33e58e9552616c7c942235abd64fee66c0d1787"
+checksum = "fd4e0689f7b3b2e98e73089bf3aa6b3290cb8a2cbff97fca2ee579cc3ca2717e"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -5868,9 +6048,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e85499464599434befb08ba5b89d4bed5cd58bf67d1d36fc8f2025605576e2"
+checksum = "ab3c3996bd418c45a540ee2c2d23e9796c244d3e5c9f135a86aa8501e1afea19"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5878,14 +6058,14 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1012c7d172982f89efefddadc07679dcc82ebf9efc9031313860c622d31725eb"
+checksum = "40927d4df440e354f618cbf9e5eb81e02cf4563ef8360782b5493f395b63f61a"
 dependencies = [
  "console",
  "dialoguer",
  "log 0.4.20",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "parking_lot 0.12.1",
  "qstring",
@@ -5897,11 +6077,11 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff3b7cbb305c5908924280dc4a2707604949a15f47b7e0953f4bfb9c0a0ff897"
+checksum = "2008d5a0bac57ef4a34c97ff93111aad7ce6849c06f4cc0b9591b0105c3523b2"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "bs58 0.4.0",
  "crossbeam-channel",
@@ -5942,8 +6122,8 @@ dependencies = [
  "solana-transaction-status",
  "solana-version",
  "solana-vote-program",
- "spl-token",
- "spl-token-2022",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
  "stream-cancel",
  "thiserror",
  "tokio",
@@ -5952,12 +6132,12 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cead295f632db6a5c9806f483dc05be50dc4e02cf54e7b8b5afb470064c8e2e3"
+checksum = "871cf6d60098c556755a3a7dbd1742201718220a13b988d012f0658eddaad674"
 dependencies = [
  "async-trait",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "bs58 0.4.0",
  "indicatif",
@@ -5978,11 +6158,11 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94b4b99de2430a5baa6c27f713dec67b934aa693fc2045f8aead5168adabea3"
+checksum = "3214d68e3b661ddfd960271f67eb8042298ac7d90d9bd86d330200c3a5518404"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "bs58 0.4.0",
  "jsonrpc-core",
  "reqwest",
@@ -5994,15 +6174,15 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022",
+ "spl-token-2022 0.6.1",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe2970736880aa250ea05a3b62dd07e5ee8e8650440f1217d3f9b6edac05d2f"
+checksum = "bcf08c480fb3d0d861abe10a0517990edea8151529ccf537c0a833233f1381d8"
 dependencies = [
  "clap 2.34.0",
  "solana-clap-utils",
@@ -6013,9 +6193,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e1591156221c91f9f76e6521ad788834e1c77f80c178675707edf4af8622e98"
+checksum = "e63ab2fb3bb128fe84bd43dedfdb5b3e03501a2f4e2121ae22a1b91106d1ca42"
 dependencies = [
  "arrayref",
  "bincode",
@@ -6038,7 +6218,7 @@ dependencies = [
  "lz4",
  "memmap2",
  "modular-bitfield",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_cpus",
  "num_enum 0.6.1",
@@ -6082,12 +6262,12 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87608d9cbf39d4f72cfb61179c320b3cea7f972671ec74dea99d255fd3a99ca9"
+checksum = "74a01f25b9f4022fc222c21c589ef7943027fb0fa2b9f6ae943fc4a65c2c01a2"
 dependencies = [
  "assert_matches",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "bitflags 1.3.2",
  "borsh 0.10.3",
@@ -6107,7 +6287,7 @@ dependencies = [
  "libsecp256k1",
  "log 0.4.20",
  "memmap2",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.6.1",
  "pbkdf2 0.11.0",
@@ -6135,22 +6315,22 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9077bd44586a902c9949d4e0cf4647ae2723ae2f0feca1e94d8fe9dcd4e2160d"
+checksum = "a75b33716470fa4a65a23ddc2d4abcb8d28532c6e3ae3f04f4fe79b5e1f8c247"
 dependencies = [
  "bs58 0.4.0",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustversion",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b80d9837d0a462599c3674be8e99977065071536db3a4ba03914eef6d74087"
+checksum = "dd9b33ec9f7bba86dc7bced3323b31de776984f674b10316fe983c0dcc052f62"
 dependencies = [
  "crossbeam-channel",
  "log 0.4.20",
@@ -6164,9 +6344,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f580a10101424ade4cf2b47f241f6e7cd72176abec7d4d72457b60f9ae6ca"
+checksum = "aa54eeb4f5cd2bcac1e593bb1907c3d0134a367dcbce0daf8c81bdd431b5f8e4"
 dependencies = [
  "bincode",
  "log 0.4.20",
@@ -6179,9 +6359,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995770bb6484ec2cc0285587561d2605dbff0cab6edea4d440752be64d6c936a"
+checksum = "0ba9edaecb25593bef3b6c01a0da10cec0035403c7eeb87b32e819f1fb4fffdc"
 dependencies = [
  "backoff",
  "bincode",
@@ -6213,9 +6393,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee11c83c33b57fa6cede3d36026e220604ef3736cd1ea0a6667ae3f364e8079b"
+checksum = "98331f48a39d7894deb0585ecf7306a699495f501b2ad37b3e5e8b7ad8f9b49d"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
@@ -6230,9 +6410,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f43f8a5e4d579a41cab0195de05fe44f8c9a171debdf355cb284320ffbf916f"
+checksum = "705ef2b2649c4162061a74aaf12f02b244828ed847ad981581e3e51155279ca5"
 dependencies = [
  "async-channel",
  "bytes 1.5.0",
@@ -6263,9 +6443,9 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f753820baf42fbc360b3b6514861c101b4de42091a87c5248ea7cd00f2dcda"
+checksum = "554ef3c25bd7c848f42bfa04b7ddfcb4f32796960ba284fd819f132b185b7b01"
 dependencies = [
  "bincode",
  "log 0.4.20",
@@ -6277,9 +6457,9 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cc93907e18bf298da73b067ae4844c6d542d4d89aadf2e18443079ab893ef7"
+checksum = "dc8a9f9c101395d314c4e5e1b19801dd54f4cd501e40b8c2d7d8b896cd2e0980"
 dependencies = [
  "bincode",
  "log 0.4.20",
@@ -6292,9 +6472,9 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec22964554632c96e2d82a4da17422ae98534bd75ea69e29f7f44c39537109d"
+checksum = "18a8a4d90f74e666cd2a5f7ac9ed230ca186d8f7351a927f061801b3ba4e8f2f"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6317,12 +6497,12 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc2fae62bb9266a196c9de6c25e484305d95a18bc05e304a176f95811a4e916"
+checksum = "c9266f75afa4163c9a5f29f1066f907e87482858749942380d6538af567b44c7"
 dependencies = [
  "Inflector",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "borsh 0.9.3",
  "bs58 0.4.0",
@@ -6334,18 +6514,18 @@ dependencies = [
  "solana-account-decoder",
  "solana-address-lookup-table-program",
  "solana-sdk",
- "spl-associated-token-account",
- "spl-memo",
- "spl-token",
- "spl-token-2022",
+ "spl-associated-token-account 1.1.3",
+ "spl-memo 3.0.1",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-udp-client"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ad75fc5355aacc4acdf8c5e4201e425c76769a74b842d1618ef58e8cdca66f"
+checksum = "e0f475a0a0faa55f7783084258c1e88be39ed3ea5c4f945bf728b7ca8c7a3262"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -6358,9 +6538,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8eed97d5addc338b857991dd26496e236f9711373cdf470682ec8548af454a3"
+checksum = "886a0c01be1e2b3a7ec3bed63f2112cd7f80c4b8182e95fa98b7ab7e37faf90a"
 dependencies = [
  "log 0.4.20",
  "rustc_version 0.4.0",
@@ -6374,13 +6554,13 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5fb2eb8114089c792929f2a2e9b4f1fa1c7d6296bbb8e5120b0a18fa6f8b75a"
+checksum = "01b1102b13ca7c760439545dba83588419d208b500a93eb61f6565be26bef490"
 dependencies = [
  "bincode",
  "log 0.4.20",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
@@ -6396,13 +6576,13 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cf6fe1d81396c4cdde367bad7964ed30e72628f0faf625b8fd75cacc789b24"
+checksum = "d33a2ae4ae1f394fced36c7f1170ecf3e597cf68eb8989877d805a384ce65a9e"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "solana-program-runtime",
  "solana-sdk",
@@ -6411,12 +6591,12 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d498188b9ff5dcef1f356888d128a9b583aee8bfe87bc6746db02b2d492f97"
+checksum = "1669c9d223d850cd96cad69d3ba1a4234bc3e2f83ac837fbdbc0ce774dac7b92"
 dependencies = [
  "aes-gcm-siv",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "bytemuck",
  "byteorder",
@@ -6425,7 +6605,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "merlin",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rand 0.7.3",
  "serde",
@@ -6487,11 +6667,62 @@ checksum = "978dba3bcbe88d0c2c58366c254d9ea41c5f73357e72fc0bdee4d6b5fc99c8f4"
 dependencies = [
  "assert_matches",
  "borsh 0.9.3",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "solana-program",
- "spl-token",
- "spl-token-2022",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-associated-token-account"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "477696277857a7b2c17a6f7f3095e835850ad1c0f11637b5bd2693ca777d8546"
+dependencies = [
+ "assert_matches",
+ "borsh 0.10.3",
+ "num-derive 0.4.0",
+ "num-traits",
+ "solana-program",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.8.0",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-discriminator"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce5d563b58ef1bb2cdbbfe0dfb9ffdc24903b10ae6a4df2d8f425ece375033f"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator-derive",
+]
+
+[[package]]
+name = "spl-discriminator-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4fa8f409b5c5e0ac571df17c981ae1424b204743daa4428430627d38717caf5"
+dependencies = [
+ "quote 1.0.33",
+ "spl-discriminator-syn",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "spl-discriminator-syn"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21968d7da2f0a624c509f24580c3fee70b364a6886d90709e679e64f572eca2f"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "solana-program",
+ "syn 2.0.33",
  "thiserror",
 ]
 
@@ -6505,6 +6736,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-memo"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f180b03318c3dbab3ef4e1e4d46d5211ae3c780940dd0a28695aba4b59a75a"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
+name = "spl-pod"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2881dddfca792737c0706fa0175345ab282b1b0879c7d877bad129645737c079"
+dependencies = [
+ "borsh 0.10.3",
+ "bytemuck",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-program-error",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249e0318493b6bcf27ae9902600566c689b7dfba9f1bdff5893e92253374e78c"
+dependencies = [
+ "num-derive 0.4.0",
+ "num-traits",
+ "solana-program",
+ "spl-program-error-derive",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6709c5f41fefb730f2bd8464da741079cf0efd1d0f522e041224b98d431b9b3"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "solana-program",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7960b1e1a41e4238807fca0865e72a341b668137a3f2ddcd770d04fd1b374c96"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
+]
+
+[[package]]
 name = "spl-token"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6512,9 +6804,24 @@ checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.5.11",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08459ba1b8f7c1020b4582c4edf0f5c7511a5e099a7a97570c9698d4f2337060"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.3.3",
+ "num-traits",
+ "num_enum 0.6.1",
  "solana-program",
  "thiserror",
 ]
@@ -6527,14 +6834,79 @@ checksum = "0043b590232c400bad5ee9eb983ced003d15163c4c5d56b090ac6d9a57457b47"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.5.11",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-memo",
- "spl-token",
+ "spl-memo 3.0.1",
+ "spl-token 3.5.0",
  "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fc0c7a763c3f53fa12581d07ed324548a771bb648a1217e4f330b1d0a59331"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.4.0",
+ "num-traits",
+ "num_enum 0.7.0",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo 4.0.0",
+ "spl-pod",
+ "spl-token 4.0.0",
+ "spl-token-metadata-interface",
+ "spl-transfer-hook-interface",
+ "spl-type-length-value",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c16ce3ba6979645fb7627aa1e435576172dd63088dc7848cb09aa331fa1fe4f"
+dependencies = [
+ "borsh 0.10.3",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7489940049417ae5ce909314bead0670e2a5ea5c82d43ab96dc15c8fcbbccba"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-tlv-account-resolution",
+ "spl-type-length-value",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a468e6f6371f9c69aae760186ea9f1a01c2908351b06a5e0026d21cfc4d7ecac"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
 ]
 
 [[package]]
@@ -6582,7 +6954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
@@ -6651,8 +7023,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b81886169f446e22edc18ead7addd9ebd141c39bf2286cb37943c92cd3af724"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytemuck",
  "rust_decimal",
  "solana-program",
@@ -6682,18 +7054,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "unicode-ident",
 ]
@@ -6710,7 +7082,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
@@ -6757,7 +7129,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -6814,9 +7186,9 @@ version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -6970,7 +7342,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -7140,9 +7512,9 @@ checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",
@@ -7190,7 +7562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease 0.1.25",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "prost-build",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -7247,9 +7619,9 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -7386,9 +7758,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -7584,9 +7956,9 @@ dependencies = [
  "bumpalo",
  "log 0.4.20",
  "once_cell",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
  "wasm-bindgen-shared",
 ]
 
@@ -7618,9 +7990,9 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7991,9 +8363,9 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.33",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3742,7 +3742,6 @@ dependencies = [
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
  "static_assertions",
- "switchboard-common",
  "switchboard-program",
  "switchboard-solana",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ members = [
 
 [workspace.dependencies]
 # 2af9cc669 is a successor of 0.28.0
-anchor-client = { git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669", version = "0.28.0" }
-anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669", version = "0.28.0" }
-anchor-spl = { git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669", version = "0.28.0" }
+anchor-client = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary", version = "0.28.0" }
+anchor-lang = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary", version = "0.28.0" }
+anchor-spl = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary", version = "0.28.0" }
 fixed = { git = "https://github.com/blockworks-foundation/fixed.git", branch = "v1.11.0-borsh0_10-mango" }
 pyth-sdk-solana = "0.8.0"
 solana-account-decoder = "~1.16.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,9 @@ members = [
 ]
 
 [workspace.dependencies]
-# note: anchor was patched - see 'patch' section
-anchor-client = { version = "0.28.0" }
-anchor-lang = { version = "0.28.0" }
-anchor-spl = { version = "0.28.0" }
+anchor-client = { version = "0.28.0", git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669" }
+anchor-lang = { version = "0.28.0", git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669" }
+anchor-spl = { version = "0.28.0", git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669" }
 fixed = { git = "https://github.com/blockworks-foundation/fixed.git", branch = "v1.11.0-borsh0_10-mango" }
 pyth-sdk-solana = "0.8.0"
 solana-account-decoder = "~1.16.1"
@@ -28,9 +27,4 @@ overflow-checks = true
 codegen-units = 1
 incremental = false
 opt-level = 3
-
-[patch.crates-io]
-anchor-client = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary" }
-anchor-lang = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary" }
-anchor-spl = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ members = [
 ]
 
 [workspace.dependencies]
-anchor-client = { version = "0.28.0", git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669" }
-anchor-lang = { version = "0.28.0", git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669" }
-anchor-spl = { version = "0.28.0", git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669" }
+anchor-client = "0.28.0"
+anchor-lang = "0.28.0"
+anchor-spl = "0.28.0"
 fixed = { git = "https://github.com/blockworks-foundation/fixed.git", branch = "v1.11.0-borsh0_10-mango" }
 pyth-sdk-solana = "0.8.0"
 solana-account-decoder = "~1.16.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ members = [
 ]
 
 [workspace.dependencies]
-# 2af9cc669 is a successor of 0.28.0
-anchor-client = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary", version = "0.28.0" }
-anchor-lang = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary", version = "0.28.0" }
-anchor-spl = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary", version = "0.28.0" }
+# note: anchor was patched - see 'patch' section
+anchor-client = { version = "0.28.0" }
+anchor-lang = { version = "0.28.0" }
+anchor-spl = { version = "0.28.0" }
 fixed = { git = "https://github.com/blockworks-foundation/fixed.git", branch = "v1.11.0-borsh0_10-mango" }
 pyth-sdk-solana = "0.8.0"
 solana-account-decoder = "~1.16.1"
@@ -28,3 +28,9 @@ overflow-checks = true
 codegen-units = 1
 incremental = false
 opt-level = 3
+
+[patch.crates-io]
+anchor-client = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary" }
+anchor-lang = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary" }
+anchor-spl = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,11 @@ members = [
 ]
 
 [workspace.dependencies]
-anchor-client = "0.28.0"
-anchor-lang = "0.28.0"
-anchor-spl = "0.28.0"
-fixed = {path = "./3rdparty/fixed", version = "1.11.0"}
+# 2af9cc669 is a successor of 0.28.0
+anchor-client = { git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669", version = "0.28.0" }
+anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669", version = "0.28.0" }
+anchor-spl = { git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669", version = "0.28.0" }
+fixed = { git = "https://github.com/blockworks-foundation/fixed.git", branch = "v1.11.0-borsh0_10-mango" }
 pyth-sdk-solana = "0.8.0"
 solana-account-decoder = "~1.16.1"
 solana-client = "~1.16.1"

--- a/programs/openbook-v2/Cargo.toml
+++ b/programs/openbook-v2/Cargo.toml
@@ -53,4 +53,3 @@ solana-program-test = { workspace = true }
 solana-logger = { workspace = true }
 spl-token = { version = "^3.5.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { workspace = true, features = ["no-entrypoint"] }
-mpl-utils = { version = "0.3.2", features = ["spl-token"] }

--- a/programs/openbook-v2/Cargo.toml
+++ b/programs/openbook-v2/Cargo.toml
@@ -37,8 +37,11 @@ pyth-sdk-solana = { workspace = true }
 solana-program = { workspace = true }
 solana-sdk = { workspace = true, default-features = false, optional = true }
 static_assertions = "1.1"
-switchboard-program = ">=0.2.0"
-switchboard-v2 = "0.4.0"
+
+switchboard-program = "0.2.0"
+# note: 0.8.19 seems broken
+switchboard-common = "=0.8.18"
+switchboard-v2 = { package = "switchboard-solana", version = "0.28" }
 
 [dev-dependencies]
 async-trait = "0.1.52"

--- a/programs/openbook-v2/Cargo.toml
+++ b/programs/openbook-v2/Cargo.toml
@@ -39,8 +39,7 @@ solana-sdk = { workspace = true, default-features = false, optional = true }
 static_assertions = "1.1"
 
 switchboard-program = "0.2.0"
-# note: 0.8.19 seems broken
-switchboard-common = "=0.8.18"
+# note: switchboard-common 0.8.19 is broken, so we lock 0.8.18
 switchboard-v2 = { package = "switchboard-solana", version = "0.28" }
 
 [dev-dependencies]

--- a/programs/openbook-v2/Cargo.toml
+++ b/programs/openbook-v2/Cargo.toml
@@ -53,3 +53,4 @@ solana-program-test = { workspace = true }
 solana-logger = { workspace = true }
 spl-token = { version = "^3.5.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { workspace = true, features = ["no-entrypoint"] }
+mpl-utils = { version = "0.3.2", features = ["spl-token"] }

--- a/programs/openbook-v2/fuzz/Cargo.lock
+++ b/programs/openbook-v2/fuzz/Cargo.lock
@@ -109,11 +109,33 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faa5be5b72abea167f87c868379ba3c2be356bfca9e6f474fd055fa0f7eeb4f2"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "regex",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-access-control"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-access-control"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_2af9cc66-arbitrary)",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -123,7 +145,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f468970344c7c9f9d03b4da854fd7c54f21305059f53789d0045c1dd803f0018"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
  "bs58 0.5.0",
  "proc-macro2 1.0.66",
@@ -133,13 +155,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "anchor-attribute-account"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "bs58 0.5.0",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-account"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_2af9cc66-arbitrary)",
+ "bs58 0.5.0",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "anchor-attribute-constant"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59948e7f9ef8144c2aefb3f32a40c5fce2798baeec765ba038389e82301017ef"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.66",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-constant"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-constant"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_2af9cc66-arbitrary)",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -149,8 +215,28 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc753c9d1c7981cb8948cf7e162fb0f64558999c0413058e2d43df1df5448086"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-error"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-error"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_2af9cc66-arbitrary)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -161,8 +247,30 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38b4e172ba1b52078f53fdc9f11e3dc0668ad27997838a0aad2d148afac8c97"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-event"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-event"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_2af9cc66-arbitrary)",
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -174,9 +282,29 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eebd21543606ab61e2d83d9da37d24d3886a49f390f9c43a1964735e8c0f0d5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
  "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-program"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-program"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_2af9cc66-arbitrary)",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -187,8 +315,52 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4720d899b3686396cced9508f23dab420f1308344456ec78ef76f98fda42af"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-accounts"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-accounts"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_2af9cc66-arbitrary)",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-serde"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "borsh-derive-internal 0.9.3",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-serde"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-syn 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_2af9cc66-arbitrary)",
+ "borsh-derive-internal 0.9.3",
  "proc-macro2 1.0.66",
  "quote 1.0.33",
  "syn 1.0.109",
@@ -206,23 +378,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "anchor-derive-space"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-space"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "anchor-lang"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d2d4b20100f1310a774aba3471ef268e5c4ba4d5c28c0bbe663c2658acbc414"
 dependencies = [
- "anchor-attribute-access-control",
- "anchor-attribute-account",
- "anchor-attribute-constant",
- "anchor-attribute-error",
- "anchor-attribute-event",
- "anchor-attribute-program",
- "anchor-derive-accounts",
- "anchor-derive-space",
+ "anchor-attribute-access-control 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-account 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-constant 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-error 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-event 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-attribute-program 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-derive-accounts 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-derive-space 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayref",
  "base64 0.13.1",
  "bincode",
  "borsh 0.10.3",
+ "bytemuck",
+ "getrandom 0.2.10",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-lang"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "anchor-attribute-access-control 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-account 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-constant 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-error 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-event 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-attribute-program 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-derive-accounts 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-derive-serde 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-derive-space 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "arrayref",
+ "base64 0.13.1",
+ "bincode",
+ "borsh 0.9.3",
+ "bytemuck",
+ "getrandom 0.2.10",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-lang"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-attribute-access-control 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-account 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-constant 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-error 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-event 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-attribute-program 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-derive-accounts 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-derive-serde 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-derive-space 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "arrayref",
+ "base64 0.13.1",
+ "bincode",
+ "borsh 0.9.3",
  "bytemuck",
  "getrandom 0.2.10",
  "solana-program",
@@ -235,7 +475,31 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78f860599da1c2354e7234c768783049eb42e2f54509ecfc942d2e0076a2da7b"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
+ "spl-associated-token-account",
+ "spl-token",
+ "spl-token-2022",
+]
+
+[[package]]
+name = "anchor-spl"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
+dependencies = [
+ "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "solana-program",
+ "spl-associated-token-account",
+ "spl-token",
+ "spl-token-2022",
+]
+
+[[package]]
+name = "anchor-spl"
+version = "0.28.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b734ca4b3a1ef4f590eec2a2dc097e5"
+dependencies = [
+ "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "solana-program",
  "spl-associated-token-account",
  "spl-token",
@@ -245,6 +509,42 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a125e4b0cc046cfec58f5aa25038e34cf440151d58f0db3afc55308251fe936d"
+dependencies = [
+ "anyhow",
+ "bs58 0.5.0",
+ "heck 0.3.3",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "serde",
+ "serde_json",
+ "sha2 0.10.7",
+ "syn 1.0.109",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-syn"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_2af9cc66-arbitrary#cc35236d9a0f87516bb85030ad849a659bca5fee"
+dependencies = [
+ "anyhow",
+ "bs58 0.5.0",
+ "heck 0.3.3",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "serde",
+ "serde_json",
+ "sha2 0.10.7",
+ "syn 1.0.109",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-syn"
+version = "0.28.0"
+source = "git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary#3dbf807db30804f925055e0d83c8055ee68be68a"
 dependencies = [
  "anyhow",
  "bs58 0.5.0",
@@ -1247,9 +1547,10 @@ dependencies = [
 [[package]]
 name = "fixed"
 version = "1.11.0"
+source = "git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango#01516ae3e29418feb066b67830540aa81d04df05"
 dependencies = [
  "az",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bytemuck",
  "half",
  "serde",
@@ -2233,8 +2534,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 name = "openbook-v2"
 version = "0.1.0"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
+ "anchor-spl 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "arbitrary",
  "arrayref",
  "bytemuck",
@@ -2254,8 +2555,8 @@ dependencies = [
 name = "openbook-v2-fuzz"
 version = "0.0.0"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
+ "anchor-spl 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "arbitrary",
  "base64 0.21.3",
  "bumpalo",
@@ -2611,8 +2912,8 @@ name = "raydium-amm-v3"
 version = "0.1.0"
 source = "git+https://github.com/raydium-io/raydium-clmm.git#bcee27ac83feece4f1849f4ec1b57c7f2ea12770"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayref",
  "bytemuck",
  "mpl-token-metadata",
@@ -3832,8 +4133,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b81886169f446e22edc18ead7addd9ebd141c39bf2286cb37943c92cd3af724"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytemuck",
  "rust_decimal",
  "solana-program",

--- a/programs/openbook-v2/fuzz/Cargo.lock
+++ b/programs/openbook-v2/fuzz/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+checksum = "0f2135563fb5c609d2b2b87c1e8ce7bc41b0b45430fa9661f457981503dd5bf0"
 dependencies = [
  "memchr",
 ]
@@ -111,7 +120,7 @@ checksum = "faa5be5b72abea167f87c868379ba3c2be356bfca9e6f474fd055fa0f7eeb4f2"
 dependencies = [
  "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "regex",
  "syn 1.0.109",
@@ -148,7 +157,7 @@ dependencies = [
  "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
  "bs58 0.5.0",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
@@ -184,8 +193,13 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59948e7f9ef8144c2aefb3f32a40c5fce2798baeec765ba038389e82301017ef"
 dependencies = [
+<<<<<<< Updated upstream
  "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.66",
+=======
+ "anchor-syn",
+ "proc-macro2 1.0.67",
+>>>>>>> Stashed changes
  "syn 1.0.109",
 ]
 
@@ -215,8 +229,13 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc753c9d1c7981cb8948cf7e162fb0f64558999c0413058e2d43df1df5448086"
 dependencies = [
+<<<<<<< Updated upstream
  "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.66",
+=======
+ "anchor-syn",
+ "proc-macro2 1.0.67",
+>>>>>>> Stashed changes
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -249,7 +268,7 @@ checksum = "f38b4e172ba1b52078f53fdc9f11e3dc0668ad27997838a0aad2d148afac8c97"
 dependencies = [
  "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -284,7 +303,7 @@ checksum = "4eebd21543606ab61e2d83d9da37d24d3886a49f390f9c43a1964735e8c0f0d5"
 dependencies = [
  "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -317,7 +336,7 @@ checksum = "ec4720d899b3686396cced9508f23dab420f1308344456ec78ef76f98fda42af"
 dependencies = [
  "anchor-syn 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -372,7 +391,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f495e85480bd96ddeb77b71d499247c7d4e8b501e75ecb234e9ef7ae7bd6552a"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -501,9 +520,9 @@ source = "git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669#2af9cc669b73
 dependencies = [
  "anchor-lang 0.28.0 (git+https://github.com/coral-xyz/anchor.git?rev=2af9cc669)",
  "solana-program",
- "spl-associated-token-account",
- "spl-token",
- "spl-token-2022",
+ "spl-associated-token-account 1.1.3",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
 ]
 
 [[package]]
@@ -549,7 +568,7 @@ dependencies = [
  "anyhow",
  "bs58 0.5.0",
  "heck 0.3.3",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "serde",
  "serde_json",
@@ -654,7 +673,7 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -690,7 +709,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -737,9 +756,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.3.15"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+checksum = "bb42b2197bf15ccb092b62c74515dbd8b86d0effd934795f6687c93b6e679a2c"
 dependencies = [
  "brotli",
  "flate2",
@@ -773,6 +792,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,9 +820,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bincode"
@@ -888,7 +922,7 @@ dependencies = [
  "borsh-derive-internal 0.9.3",
  "borsh-schema-derive-internal 0.9.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "syn 1.0.109",
 ]
 
@@ -901,7 +935,7 @@ dependencies = [
  "borsh-derive-internal 0.10.3",
  "borsh-schema-derive-internal 0.10.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "syn 1.0.109",
 ]
 
@@ -911,7 +945,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -922,7 +956,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -933,7 +967,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -944,7 +978,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -987,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bv"
@@ -1016,9 +1050,9 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1082,9 +1116,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1277,10 +1311,10 @@ checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "strsim",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1291,7 +1325,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1317,7 +1351,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -1328,9 +1362,9 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1387,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "eager"
@@ -1462,9 +1496,9 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1604,6 +1638,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1668,7 @@ checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1676,6 +1722,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "goblin"
@@ -1881,7 +1933,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1890,10 +1942,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "rustls",
@@ -2058,9 +2111,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2123,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
@@ -2234,24 +2287,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2270,7 +2312,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -2284,7 +2326,7 @@ dependencies = [
  "borsh 0.9.3",
  "bytemuck",
  "mpl-token-metadata-context-derive 0.2.1",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rmp-serde",
  "serde",
@@ -2305,12 +2347,12 @@ dependencies = [
  "mpl-token-auth-rules",
  "mpl-token-metadata-context-derive 0.3.0",
  "mpl-utils",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "shank",
  "solana-program",
- "spl-associated-token-account",
- "spl-token",
+ "spl-associated-token-account 2.1.0",
+ "spl-token 4.0.0",
  "thiserror",
 ]
 
@@ -2342,7 +2384,7 @@ checksum = "3f2e4f92aec317d5853c0cc4c03c55f5178511c45bb3dbb441aea63117bf3dc9"
 dependencies = [
  "arrayref",
  "solana-program",
- "spl-token-2022",
+ "spl-token-2022 0.6.1",
 ]
 
 [[package]]
@@ -2356,15 +2398,6 @@ dependencies = [
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2419,9 +2452,20 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2495,13 +2539,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+dependencies = [
+ "num_enum_derive 0.7.0",
+]
+
+[[package]]
 name = "num_enum_derive"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -2513,9 +2566,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2558,7 +2632,7 @@ dependencies = [
  "anchor-lang 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "anchor-spl 0.28.0 (git+https://github.com/openbook-dex/anchor.git?branch=v0.28.0_abfdc4e-arbitrary)",
  "arbitrary",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bumpalo",
  "env_logger 0.10.0",
  "itertools 0.11.0",
@@ -2569,7 +2643,7 @@ dependencies = [
  "solana-program",
  "solana-runtime",
  "solana-sdk",
- "spl-associated-token-account",
+ "spl-associated-token-account 1.1.3",
 ]
 
 [[package]]
@@ -2590,7 +2664,7 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -2725,7 +2799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
@@ -2737,7 +2811,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "version_check",
 ]
@@ -2753,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -2783,7 +2857,7 @@ dependencies = [
  "borsh 0.10.3",
  "borsh-derive 0.10.3",
  "bytemuck",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pyth-sdk",
  "serde",
@@ -2824,7 +2898,7 @@ version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
 ]
 
 [[package]]
@@ -2910,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "raydium-amm-v3"
 version = "0.1.0"
-source = "git+https://github.com/raydium-io/raydium-clmm.git#bcee27ac83feece4f1849f4ec1b57c7f2ea12770"
+source = "git+https://github.com/raydium-io/raydium-clmm.git#6e4639f7133a8852068d2d473c263f907b69cd4a"
 dependencies = [
  "anchor-lang 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anchor-spl 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2983,12 +3057,12 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "async-compression",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3103,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.11"
+version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -3116,14 +3190,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
@@ -3132,7 +3206,17 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3158,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.13"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763f8cd0d4c71ed8389c90cb8100cba87e763bd01a8e614d4f0af97bcd50a161"
+checksum = "1f7b0ce13155372a76ee2e1c5ffba1fe61ede73fbea5630d61eee6fac4929c0c"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -3170,11 +3254,11 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.13"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f696e21e10fa546b7ffb1c9672c6de8fbc7a81acf59524386d8639bf12737"
+checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "serde_derive_internals",
  "syn 1.0.109",
@@ -3201,9 +3285,9 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3246,9 +3330,9 @@ version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3257,16 +3341,16 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -3302,9 +3386,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3368,7 +3452,7 @@ version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63927d22a1e8b74bda98cc6e151fcdf178b7abb0dc6c4f81e0bbf5ffe2fc4ec8"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "shank_macro_impl",
  "syn 1.0.109",
@@ -3381,7 +3465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce03403df682f80f4dc1efafa87a4d0cb89b03726d0565e6364bdca5b9a441"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "serde",
  "syn 1.0.109",
@@ -3429,15 +3513,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-address-lookup-table-program"
-version = "1.16.12"
+name = "socket2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85261ec5a2cee18d926e1c48265a760896fa06a6b431b3f1d43a8b0f7a3aa28d"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "solana-address-lookup-table-program"
+version = "1.16.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd3f3e85d67e559985fbdc6b5b4d5dd9c8462b78e6079c3b465496c1f3c55d6"
 dependencies = [
  "bincode",
  "bytemuck",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rustc_version",
  "serde",
@@ -3451,9 +3545,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cd08c1708e67b916868d967c8b88aeeee042b13e3c694281e0b70a99eed71e"
+checksum = "3da230f2ff22007e2ca60507346488a65ec274fbb2486bdd2d10948eef2c03d8"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3470,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be4e8f905d14b4b6dd8430af81b56ebb964377615784f70f36cf6a70436c03a"
+checksum = "89e8716aa59039a8eeac13a5d090561ae11a252d674e9b41d97fe382a70545b9"
 dependencies = [
  "bv",
  "log",
@@ -3487,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ee0c59cd7880b1c39878d18308d324450c4ee724f892d418d6891c18da142c"
+checksum = "552f79e747bd8bb7baa229007f5ff54971f67ec6f0f9d2a06a95adfaabe3f19c"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -3497,9 +3591,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2c6b161fc8e7bd86733559eaf6142f271dda233efd7fa1e2edacf98b4cc4cd"
+checksum = "0a35e4cc9f2996a2ef95aac398443fc4a110ef585521e11a7685b3591648b7cf"
 dependencies = [
  "bincode",
  "chrono",
@@ -3511,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0447b0bb6ab6c6fc0e83bd106618c23d241c4fb8090de715a9811fb993fbfd07"
+checksum = "35b9e2169fd13394af838b13f047067c35ce69372aea0fb46e026405b5e931f9"
 dependencies = [
  "ahash 0.8.3",
  "blake3",
@@ -3544,21 +3638,21 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc86a118888cef8a3878f6dc9c291787cb21ef50cd98e7271f1e0ff548153b8"
+checksum = "db08ab0af4007dc0954b900aa5febc0c0ae50d9f9f598be27263c3195d90240b"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustc_version",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7928dba97891bc52fe2a8d1e10db959029763dfb43e44519061df4fc91f9c514"
+checksum = "e84811758fce4dcfd9617a7c3178effe9e59480d43c1e862bb3c8daccfcfd61d"
 dependencies = [
  "log",
  "rand 0.7.3",
@@ -3570,9 +3664,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac77d7fc0144181d4f6c8eb4203bb5fe54d486fa19ccaab7615ccb4b874b0de"
+checksum = "bf8a48e734f78a44399516f7c130c114b455911e351f001abc0d96e7c5694efa"
 dependencies = [
  "env_logger 0.9.3",
  "lazy_static",
@@ -3581,9 +3675,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441deecebeb23ff7da89df5db5ec712458903c7cc733c8ae1e0a26daf2c1130a"
+checksum = "d3529d2ff63ceedd3707c51188aacb9e3c142118de3f55447c40584a78223ffd"
 dependencies = [
  "log",
  "solana-sdk",
@@ -3591,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229583448485d731afb88e2bfd3a6b978312d4690c7452a35f8da47c02d4fd4f"
+checksum = "4792f29de5378a13c51be3fa9fdd526a20550b5ffabd7d1a57a4e49468e17d90"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -3605,9 +3699,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103fe87a578aa1771ee992e2654b2830ffc16709d429c3bb0d2c36ef8fee4d1d"
+checksum = "9218d9c823b22a465f91c966e8254a5f57b6817e0121ec6d4bf9a5ddc8307f18"
 dependencies = [
  "ahash 0.8.3",
  "bincode",
@@ -3632,16 +3726,16 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3841458623bd80b8291e8991f7353d674bb39656b1db83ec1aa5916a1b6ed7c"
+checksum = "2f17a1fbcf1e94e282db16153d323b446d6386ac99f597f78e76332265829336"
 dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
  "array-bytes",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "bitflags 1.3.2",
  "blake3",
@@ -3663,7 +3757,7 @@ dependencies = [
  "log",
  "memoffset 0.9.0",
  "num-bigint 0.4.4",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "parking_lot",
  "rand 0.7.3",
@@ -3687,18 +3781,18 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cc1b1f3a5a9f6735668a67e3d1fe161ec2d4931ef523acc4d716704b9fc11f"
+checksum = "2ff9f0c8043b2e7921e25a3fee88fa253b8cb5dbab1e521a4d83e78e8874c551"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "eager",
  "enum-iterator",
  "itertools 0.10.5",
  "libc",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "percentage",
  "rand 0.7.3",
@@ -3715,9 +3809,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e85499464599434befb08ba5b89d4bed5cd58bf67d1d36fc8f2025605576e2"
+checksum = "ab3c3996bd418c45a540ee2c2d23e9796c244d3e5c9f135a86aa8501e1afea19"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -3725,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e1591156221c91f9f76e6521ad788834e1c77f80c178675707edf4af8622e98"
+checksum = "e63ab2fb3bb128fe84bd43dedfdb5b3e03501a2f4e2121ae22a1b91106d1ca42"
 dependencies = [
  "arrayref",
  "bincode",
@@ -3750,7 +3844,7 @@ dependencies = [
  "lz4",
  "memmap2",
  "modular-bitfield",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_cpus",
  "num_enum 0.6.1",
@@ -3794,12 +3888,12 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87608d9cbf39d4f72cfb61179c320b3cea7f972671ec74dea99d255fd3a99ca9"
+checksum = "74a01f25b9f4022fc222c21c589ef7943027fb0fa2b9f6ae943fc4a65c2c01a2"
 dependencies = [
  "assert_matches",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "bitflags 1.3.2",
  "borsh 0.10.3",
@@ -3819,7 +3913,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "memmap2",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.6.1",
  "pbkdf2 0.11.0",
@@ -3847,22 +3941,22 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9077bd44586a902c9949d4e0cf4647ae2723ae2f0feca1e94d8fe9dcd4e2160d"
+checksum = "a75b33716470fa4a65a23ddc2d4abcb8d28532c6e3ae3f04f4fe79b5e1f8c247"
 dependencies = [
  "bs58 0.4.0",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustversion",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f580a10101424ade4cf2b47f241f6e7cd72176abec7d4d72457b60f9ae6ca"
+checksum = "aa54eeb4f5cd2bcac1e593bb1907c3d0134a367dcbce0daf8c81bdd431b5f8e4"
 dependencies = [
  "bincode",
  "log",
@@ -3875,9 +3969,9 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f753820baf42fbc360b3b6514861c101b4de42091a87c5248ea7cd00f2dcda"
+checksum = "554ef3c25bd7c848f42bfa04b7ddfcb4f32796960ba284fd819f132b185b7b01"
 dependencies = [
  "bincode",
  "log",
@@ -3889,13 +3983,13 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5fb2eb8114089c792929f2a2e9b4f1fa1c7d6296bbb8e5120b0a18fa6f8b75a"
+checksum = "01b1102b13ca7c760439545dba83588419d208b500a93eb61f6565be26bef490"
 dependencies = [
  "bincode",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rustc_version",
  "serde",
@@ -3911,13 +4005,13 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cf6fe1d81396c4cdde367bad7964ed30e72628f0faf625b8fd75cacc789b24"
+checksum = "d33a2ae4ae1f394fced36c7f1170ecf3e597cf68eb8989877d805a384ce65a9e"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "solana-program-runtime",
  "solana-sdk",
@@ -3926,12 +4020,12 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.16.12"
+version = "1.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d498188b9ff5dcef1f356888d128a9b583aee8bfe87bc6746db02b2d492f97"
+checksum = "1669c9d223d850cd96cad69d3ba1a4234bc3e2f83ac837fbdbc0ce774dac7b92"
 dependencies = [
  "aes-gcm-siv",
- "base64 0.21.3",
+ "base64 0.21.4",
  "bincode",
  "bytemuck",
  "byteorder",
@@ -3940,7 +4034,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "merlin",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rand 0.7.3",
  "serde",
@@ -3986,11 +4080,62 @@ checksum = "978dba3bcbe88d0c2c58366c254d9ea41c5f73357e72fc0bdee4d6b5fc99c8f4"
 dependencies = [
  "assert_matches",
  "borsh 0.9.3",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "solana-program",
- "spl-token",
- "spl-token-2022",
+ "spl-token 3.5.0",
+ "spl-token-2022 0.6.1",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-associated-token-account"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "477696277857a7b2c17a6f7f3095e835850ad1c0f11637b5bd2693ca777d8546"
+dependencies = [
+ "assert_matches",
+ "borsh 0.10.3",
+ "num-derive 0.4.0",
+ "num-traits",
+ "solana-program",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.8.0",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-discriminator"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce5d563b58ef1bb2cdbbfe0dfb9ffdc24903b10ae6a4df2d8f425ece375033f"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator-derive",
+]
+
+[[package]]
+name = "spl-discriminator-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4fa8f409b5c5e0ac571df17c981ae1424b204743daa4428430627d38717caf5"
+dependencies = [
+ "quote 1.0.33",
+ "spl-discriminator-syn",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "spl-discriminator-syn"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21968d7da2f0a624c509f24580c3fee70b364a6886d90709e679e64f572eca2f"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "solana-program",
+ "syn 2.0.37",
  "thiserror",
 ]
 
@@ -4004,6 +4149,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-memo"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f180b03318c3dbab3ef4e1e4d46d5211ae3c780940dd0a28695aba4b59a75a"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
+name = "spl-pod"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2881dddfca792737c0706fa0175345ab282b1b0879c7d877bad129645737c079"
+dependencies = [
+ "borsh 0.10.3",
+ "bytemuck",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-program-error",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249e0318493b6bcf27ae9902600566c689b7dfba9f1bdff5893e92253374e78c"
+dependencies = [
+ "num-derive 0.4.0",
+ "num-traits",
+ "solana-program",
+ "spl-program-error-derive",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6709c5f41fefb730f2bd8464da741079cf0efd1d0f522e041224b98d431b9b3"
+dependencies = [
+ "proc-macro2 1.0.67",
+ "quote 1.0.33",
+ "solana-program",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7960b1e1a41e4238807fca0865e72a341b668137a3f2ddcd770d04fd1b374c96"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
+]
+
+[[package]]
 name = "spl-token"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4011,9 +4217,24 @@ checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.5.11",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08459ba1b8f7c1020b4582c4edf0f5c7511a5e099a7a97570c9698d4f2337060"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.3.3",
+ "num-traits",
+ "num_enum 0.6.1",
  "solana-program",
  "thiserror",
 ]
@@ -4026,14 +4247,79 @@ checksum = "0043b590232c400bad5ee9eb983ced003d15163c4c5d56b090ac6d9a57457b47"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.5.11",
  "solana-program",
  "solana-zk-token-sdk",
- "spl-memo",
- "spl-token",
+ "spl-memo 3.0.1",
+ "spl-token 3.5.0",
  "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fc0c7a763c3f53fa12581d07ed324548a771bb648a1217e4f330b1d0a59331"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.4.0",
+ "num-traits",
+ "num_enum 0.7.0",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo 4.0.0",
+ "spl-pod",
+ "spl-token 4.0.0",
+ "spl-token-metadata-interface",
+ "spl-transfer-hook-interface",
+ "spl-type-length-value",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c16ce3ba6979645fb7627aa1e435576172dd63088dc7848cb09aa331fa1fe4f"
+dependencies = [
+ "borsh 0.10.3",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-type-length-value",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7489940049417ae5ce909314bead0670e2a5ea5c82d43ab96dc15c8fcbbccba"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+ "spl-tlv-account-resolution",
+ "spl-type-length-value",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a468e6f6371f9c69aae760186ea9f1a01c2908351b06a5e0026d21cfc4d7ecac"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
 ]
 
 [[package]]
@@ -4064,7 +4350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
@@ -4164,18 +4450,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
  "unicode-ident",
 ]
@@ -4206,9 +4492,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -4228,9 +4514,9 @@ version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4269,36 +4555,35 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.14.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d0183f6f6001549ab68f8c7585093bb732beefbcf6d23a10b9b95c73a1dd49"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
- "winapi",
+ "socket2 0.5.4",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4325,9 +4610,9 @@ checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",
@@ -4348,19 +4633,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
-dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
- "syn 2.0.31",
 ]
 
 [[package]]
@@ -4380,9 +4653,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uint"
@@ -4404,9 +4677,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -4537,9 +4810,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -4571,9 +4844,9 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4595,23 +4868,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "winapi"
@@ -4730,11 +4990,12 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4761,9 +5022,9 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.67",
  "quote 1.0.33",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/programs/openbook-v2/fuzz/Cargo.toml
+++ b/programs/openbook-v2/fuzz/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669", version = "0.28.0" }
-anchor-spl = { git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669", version = "0.28.0" }
+anchor-lang = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary", version = "0.28.0" }
+anchor-spl = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_abfdc4e-arbitrary", version = "0.28.0" }
 arbitrary = { version = "~1.0", features = ["derive"] }
 bumpalo = "3.13.0"
 libfuzzer-sys = "0.4"
@@ -22,9 +22,6 @@ log = "0.4.19"
 base64 = "0.21.2"
 itertools = "0.11.0"
 num_enum = "0.6.1"
-
-[patch.crates-io]
-anchor-syn = { path = "../../../3rdparty/anchor/lang/syn" }
 
 [dependencies.openbook-v2]
 path = ".."

--- a/programs/openbook-v2/fuzz/Cargo.toml
+++ b/programs/openbook-v2/fuzz/Cargo.toml
@@ -39,3 +39,6 @@ name = "multiple_orders"
 path = "fuzz_targets/multiple_orders.rs"
 test = false
 doc = false
+
+[patch."https://github.com/coral-xyz/anchor.git"]
+anchor-syn = { git = "https://github.com/openbook-dex/anchor.git", branch = "v0.28.0_2af9cc66-arbitrary" }

--- a/programs/openbook-v2/fuzz/Cargo.toml
+++ b/programs/openbook-v2/fuzz/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-anchor-lang = "0.28.0"
-anchor-spl = "0.28.0"
+anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669", version = "0.28.0" }
+anchor-spl = { git = "https://github.com/coral-xyz/anchor.git", rev = "2af9cc669", version = "0.28.0" }
 arbitrary = { version = "~1.0", features = ["derive"] }
 bumpalo = "3.13.0"
 libfuzzer-sys = "0.4"


### PR DESCRIPTION
-> anchor 0.28 + solana 1.16

- use 'fixed' with borsh 0.10
- use patched anchor 0.28
- fix: mpl token compile error