### PR TITLE
Feature/oo-indexer

### DIFF
--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -37,6 +37,9 @@ export type OracleConfigParams = IdlTypes<OpenbookV2>['OracleConfigParams'];
 export type OracleConfig = IdlTypes<OpenbookV2>['OracleConfig'];
 export type MarketAccount = IdlAccounts<OpenbookV2>['market'];
 export type OpenOrdersAccount = IdlAccounts<OpenbookV2>['openOrdersAccount'];
+// OpenOrdersIndexerAccount Type For getOpenOrdersIndexer
+export type OpenOrdersIndexerAccount = IdlAccounts<OpenbookV2>['openOrdersIndexer'];
+
 export type EventHeapAccount = IdlAccounts<OpenbookV2>['eventHeap'];
 export type BookSideAccount = IdlAccounts<OpenbookV2>['bookSide'];
 export type LeafNode = IdlTypes<OpenbookV2>['LeafNode'];
@@ -150,7 +153,16 @@ export class OpenBookV2Client {
       return null;
     }
   }
-
+  // Get the OpenOrderIndexer by using this function
+  public async getOpenOrdersIndexer(
+    publicKey: PublicKey,
+  ): Promise<OpenOrdersIndexerAccount | null> {
+    try {
+      return await this.program.account.openOrdersIndexer.fetch(publicKey);
+    } catch {
+      return null;
+    }
+  }
   public async getEventHeap(
     publicKey: PublicKey,
   ): Promise<EventHeapAccount | null> {
@@ -309,12 +321,14 @@ export class OpenBookV2Client {
   }
 
   public findOpenOrders(market: PublicKey, accountIndex: BN): PublicKey {
+    // TypeError: accountIndex.toBuffer is not a function
+    // Fix: use toArrayLike
     const [openOrders] = PublicKey.findProgramAddressSync(
       [
         Buffer.from('OpenOrders'),
         this.walletPk.toBuffer(),
         market.toBuffer(),
-        accountIndex.toBuffer('le', 4),
+        accountIndex.toArrayLike(Buffer, 'le', 4)
       ],
       this.programId,
     );

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -37,9 +37,8 @@ export type OracleConfigParams = IdlTypes<OpenbookV2>['OracleConfigParams'];
 export type OracleConfig = IdlTypes<OpenbookV2>['OracleConfig'];
 export type MarketAccount = IdlAccounts<OpenbookV2>['market'];
 export type OpenOrdersAccount = IdlAccounts<OpenbookV2>['openOrdersAccount'];
-// OpenOrdersIndexerAccount Type For getOpenOrdersIndexer
-export type OpenOrdersIndexerAccount = IdlAccounts<OpenbookV2>['openOrdersIndexer'];
-
+export type OpenOrdersIndexerAccount =
+  IdlAccounts<OpenbookV2>['openOrdersIndexer'];
 export type EventHeapAccount = IdlAccounts<OpenbookV2>['eventHeap'];
 export type BookSideAccount = IdlAccounts<OpenbookV2>['bookSide'];
 export type LeafNode = IdlTypes<OpenbookV2>['LeafNode'];
@@ -153,7 +152,7 @@ export class OpenBookV2Client {
       return null;
     }
   }
-  // Get the OpenOrderIndexer by using this function
+
   public async getOpenOrdersIndexer(
     publicKey: PublicKey,
   ): Promise<OpenOrdersIndexerAccount | null> {
@@ -163,6 +162,7 @@ export class OpenBookV2Client {
       return null;
     }
   }
+
   public async getEventHeap(
     publicKey: PublicKey,
   ): Promise<EventHeapAccount | null> {
@@ -208,8 +208,8 @@ export class OpenBookV2Client {
     name: string,
     quoteMint: PublicKey,
     baseMint: PublicKey,
-    quoteLoteSize: BN,
-    baseLoteSize: BN,
+    quoteLotSize: BN,
+    baseLotSize: BN,
     makerFee: BN,
     takerFee: BN,
     timeExpiry: BN,
@@ -259,8 +259,8 @@ export class OpenBookV2Client {
       .createMarket(
         name,
         oracleConfigParams,
-        quoteLoteSize,
-        baseLoteSize,
+        quoteLotSize,
+        baseLotSize,
         makerFee,
         takerFee,
         timeExpiry,
@@ -321,14 +321,12 @@ export class OpenBookV2Client {
   }
 
   public findOpenOrders(market: PublicKey, accountIndex: BN): PublicKey {
-    // TypeError: accountIndex.toBuffer is not a function
-    // Fix: use toArrayLike
     const [openOrders] = PublicKey.findProgramAddressSync(
       [
         Buffer.from('OpenOrders'),
         this.walletPk.toBuffer(),
         market.toBuffer(),
-        accountIndex.toArrayLike(Buffer, 'le', 4)
+        accountIndex.toArrayLike(Buffer, 'le', 4),
       ],
       this.programId,
     );


### PR DESCRIPTION
**TS Client Updates**

This PR aims to;
- Introduce a new type alias and function for indexing open-orders.
- Support for VersionedTransactions.
- Fix minor TypeErrors.


new type alias: `OpenOrdersIndexerAccount`
new function: `getOpenOrdersIndexer`
versionedtransactions: `maxSupportedTransactionVersion: 0`