### PR TITLE
Fix program ID in Anchor.toml

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -2,7 +2,7 @@
 seeds = false
 skip-lint = false
 [programs.localnet]
-openbook_v2 = "8qkavBpvoHVYkmPhu6QRpXRX39Kcop9uMXvZorBAz43o"
+openbook_v2 = "opnbkNkqux64GppQhwbyEVc3axhssFhVYuwar8rDHCu"
 
 [registry]
 url = "https://api.apr.dev"


### PR DESCRIPTION
I'm working on something that CPIs into openbook, and I forgot that the repo uses non-anchor tests so Anchor.toml isn't used the same way, so I pulled in the wrong program ID. This updates it so that someone else wouldn't make the same mistake.