### PR TITLE
Modify the ts client to allow for an `openbook_twap` program

### DIFF
--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -224,7 +224,7 @@ export class OpenBookV2Client {
       maxStalenessSlots: 100,
     },
     collectFeeAdmin?: PublicKey,
-  ): Promise<string> {
+  ): Promise<PublicKey> {
     const bids = await this.createProgramAccount(payer, BooksideSpace);
     const asks = await this.createProgramAccount(payer, BooksideSpace);
     const eventHeap = await this.createProgramAccount(payer, EventHeapSpace);
@@ -288,9 +288,11 @@ export class OpenBookV2Client {
       })
       .instruction();
 
-    return await this.sendAndConfirmTransaction([ix], {
+    await this.sendAndConfirmTransaction([ix], {
       additionalSigners: [payer, market],
     });
+
+    return market.publicKey;
   }
 
   public findOpenOrdersIndexer(): PublicKey {

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -336,7 +336,7 @@ export class OpenBookV2Client {
     market: PublicKey,
     accountIndex: BN,
     openOrdersIndexer?: PublicKey,
-  ): Promise<TransactionSignature> {
+  ): Promise<PublicKey> {
     if (openOrdersIndexer == null) {
       openOrdersIndexer = this.findOpenOrdersIndexer();
       try {
@@ -370,7 +370,9 @@ export class OpenBookV2Client {
       })
       .instruction();
 
-    return await this.sendAndConfirmTransaction([ix]);
+    await this.sendAndConfirmTransaction([ix]);
+
+    return openOrders;
   }
 
   public async deposit(

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -223,13 +223,13 @@ export class OpenBookV2Client {
       confFilter: 0.1,
       maxStalenessSlots: 100,
     },
+    market = Keypair.generate(),
     collectFeeAdmin?: PublicKey,
   ): Promise<PublicKey> {
     const bids = await this.createProgramAccount(payer, BooksideSpace);
     const asks = await this.createProgramAccount(payer, BooksideSpace);
     const eventHeap = await this.createProgramAccount(payer, EventHeapSpace);
 
-    const market = Keypair.generate();
     const [marketAuthority] = PublicKey.findProgramAddressSync(
       [Buffer.from('Market'), market.publicKey.toBuffer()],
       this.program.programId,


### PR DESCRIPTION
I'm currently working on an `openbook_twap` program that sits on top of `openbook_v2` and, for specific markets, feeds prices into a TWAP aggregator. These changes made the TS client more convenient to work with, and I think would be generally beneficial. They include:
- return the market's pubkey from `createMarket`, so that you can use the market in future instructions
- allow the client to pass the market Keypair, so that I can first generate a keypair, then generate a PDA that will be the Market's `open_orders_authority`, then create the market