### PR TITLE
Add scripts

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -13,3 +13,4 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+createMarket = "npx ts-node -O \"{\\\"module\\\": \\\"commonjs\\\"}\" scripts/createMarket.ts"

--- a/scripts/createMarket.ts
+++ b/scripts/createMarket.ts
@@ -1,0 +1,7 @@
+import {
+  OpenBookV2Client
+} from "@openbook-dex/openbook-v2";
+import * as anchor from "@coral-xyz/anchor";
+
+const provider = anchor.AnchorProvider.env();
+anchor.setProvider(provider);


### PR DESCRIPTION
The idea here would be to use anchor's in-built script functionality (e.g., giving providers for devnet and for different keys) rather than rolling our own, as is done in scripts-v2