### PR TITLE
Make SDK compatible with bankrun

### DIFF
--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -82,7 +82,7 @@ export class OpenBookV2Client {
     this.postSendTxCallback = opts?.postSendTxCallback;
     this.txConfirmationCommitment =
       opts?.txConfirmationCommitment ??
-      (this.program.provider as AnchorProvider).opts.commitment ??
+//      (this.program.provider as AnchorProvider).opts.commitment ??
       'processed';
     // TODO: evil side effect, but limited backtraces are a nightmare
     Error.stackTraceLimit = 1000;

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -82,8 +82,10 @@ export class OpenBookV2Client {
     this.postSendTxCallback = opts?.postSendTxCallback;
     this.txConfirmationCommitment =
       opts?.txConfirmationCommitment ??
-//      (this.program.provider as AnchorProvider).opts.commitment ??
-      'processed';
+      ((this.program.provider as AnchorProvider).opts !== undefined ?
+       (this.program.provider as AnchorProvider).opts.commitment : 
+       undefined) ??
+       'processed';
     // TODO: evil side effect, but limited backtraces are a nightmare
     Error.stackTraceLimit = 1000;
   }


### PR DESCRIPTION
I use a Solana testing framework called
[bankrun](https://github.com/kevinheavey/solana-bankrun/tree/main). This patch makes the SDK compatible with bankrun.