### PR TITLE
Refactor ts open orders creation

### DIFF
--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -305,7 +305,7 @@ export class OpenBookV2Client {
     return market.publicKey;
   }
 
-  public findOpenOrdersIndexer(owner: PublicKey): PublicKey {
+  public findOpenOrdersIndexer(owner: PublicKey = this.walletPk): PublicKey {
     const [openOrdersIndexer] = PublicKey.findProgramAddressSync(
       [Buffer.from('OpenOrdersIndexer'), owner.toBuffer()],
       this.programId,


### PR DESCRIPTION
This way allows owners other than the payer and also allows you to just generate instructions, which is useful if you don't have a `Keypair` (as is the case in a UI).