### PR TITLE
Remove `fs` and `eslist-config-prettier` from cli deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.28.0",
     "@solana/spl-token": "0.3.8",
-    "@solana/web3.js": "^1.77.3",
-    "eslint-config-prettier": "^8.10.0",
-    "fs": "^0.0.1-security"
+    "@solana/web3.js": "^1.77.3"
   },
   "devDependencies": {
+    "eslint-config-prettier": "^8.10.0",
+    "fs": "^0.0.1-security",
     "@types/bn.js": "^5.1.0",
     "@types/chai": "^4.3.0",
     "@types/mocha": "^9.0.0",


### PR DESCRIPTION
My webapp doesn't work with the fs dependency (no file system in web browser), and I figured eslint-config-prettier was also meant as a dev dep.