### PR TITLE
fix: add back workspace-inheritance

### DIFF
--- a/lib/client/Cargo.toml
+++ b/lib/client/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 edition = "2021"
 name = "openbook-v2-client"

--- a/programs/openbook-v2/Cargo.toml
+++ b/programs/openbook-v2/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["workspace-inheritance"]
+
 [package]
 description = "Created with Anchor"
 edition = "2021"


### PR DESCRIPTION
Clippy warns about this not being required, but builds are failing without it. Best add it back in! Sorry!