### PR TITLE
Feature/dont fail insufficient funds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3358,6 +3373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg 1.1.0",
+ "libm",
 ]
 
 [[package]]
@@ -3479,6 +3495,8 @@ dependencies = [
  "log 0.4.20",
  "num 0.4.1",
  "num_enum 0.5.11",
+ "proptest",
+ "proptest-derive",
  "pyth-sdk-solana",
  "rand 0.8.5",
  "raydium-amm-v3",
@@ -3954,6 +3972,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.4.1",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4057,6 +4106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-protobuf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4148,7 +4203,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi 0.3.9",
 ]
 
@@ -4308,6 +4363,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4700,6 +4764,18 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -7644,6 +7720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7816,6 +7898,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/programs/openbook-v2/Cargo.toml
+++ b/programs/openbook-v2/Cargo.toml
@@ -54,3 +54,5 @@ solana-program-test = { workspace = true }
 solana-logger = { workspace = true }
 spl-token = { version = "^3.5.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { workspace = true, features = ["no-entrypoint"] }
+proptest = "1.4.0"
+proptest-derive = "0.4.0"

--- a/programs/openbook-v2/src/instructions/cancel_and_place_orders.rs
+++ b/programs/openbook-v2/src/instructions/cancel_and_place_orders.rs
@@ -11,7 +11,7 @@ use crate::token_utils::*;
 pub fn cancel_and_place_orders(
     ctx: Context<CancelAndPlaceOrders>,
     cancel_client_orders_ids: Vec<u64>,
-    orders: Vec<Order>,
+    mut orders: Vec<Order>,
     limits: Vec<u8>,
 ) -> Result<Vec<Option<u128>>> {
     let mut open_orders_account = ctx.accounts.open_orders_account.load_mut()?;
@@ -63,12 +63,37 @@ pub fn cancel_and_place_orders(
     let mut base_amount = 0_u64;
     let mut quote_amount = 0_u64;
     let mut order_ids = Vec::new();
-    for (order, limit) in orders.iter().zip(limits) {
+    for (order, limit) in orders.iter_mut().zip(limits) {
         require_gte!(order.max_base_lots, 0, OpenBookError::InvalidInputLots);
         require_gte!(
             order.max_quote_lots_including_fees,
             0,
             OpenBookError::InvalidInputLots
+        );
+
+        let max_available_base = ctx.accounts.user_base_account.amount
+            + open_orders_account.position.base_free_native
+            - base_amount;
+
+        let max_available_quote = ctx.accounts.user_quote_account.amount
+            + open_orders_account.position.quote_free_native
+            - quote_amount;
+
+        order.max_base_lots = std::cmp::min(
+            order.max_base_lots,
+            market.max_base_lots_from_lamports(max_available_base),
+        );
+
+        order.max_quote_lots_including_fees = std::cmp::min(
+            order.max_quote_lots_including_fees,
+            market.max_quote_lots_from_lamports(max_available_quote, order.side),
+        );
+
+        msg!("LOOP {} {}", max_available_base, max_available_quote);
+        msg!(
+            "LOOP {} {}",
+            order.max_base_lots,
+            order.max_quote_lots_including_fees
         );
 
         let OrderWithAmounts {

--- a/programs/openbook-v2/src/state/market.rs
+++ b/programs/openbook-v2/src/state/market.rs
@@ -196,6 +196,24 @@ impl Market {
         i64::MAX / self.quote_lot_size
     }
 
+    pub fn max_base_lots_from_lamports(&self, lamports: u64) -> i64 {
+        (lamports / self.base_lot_size as u64) as i64
+    }
+
+    pub fn max_quote_lots_from_lamports(&self, lamports: u64, side: Side) -> i64 {
+        let mut quote_lots = lamports / self.quote_lot_size as u64;
+
+        if side == Side::Bid {
+            let dust = lamports - quote_lots * self.quote_lot_size as u64;
+
+            if dust >= self.taker_fees_ceil(quote_lots + 1) {
+                quote_lots += 1;
+            }
+        };
+
+        quote_lots as i64
+    }
+
     /// Convert from the price stored on the book to the price used in value calculations
     pub fn lot_to_native_price(&self, price: i64) -> I80F48 {
         I80F48::from_num(price) * I80F48::from_num(self.quote_lot_size)

--- a/programs/openbook-v2/src/state/market.rs
+++ b/programs/openbook-v2/src/state/market.rs
@@ -197,7 +197,10 @@ impl Market {
     }
 
     pub fn max_base_lots_from_lamports(&self, lamports: u64) -> i64 {
-        (lamports / self.base_lot_size as u64) as i64
+        let base_lots = lamports / self.base_lot_size as u64;
+        std::cmp::min(self.max_base_lots() as u64, base_lots)
+            .try_into()
+            .unwrap()
     }
 
     pub fn max_quote_lots_from_lamports(&self, lamports: u64, side: Side) -> i64 {
@@ -211,7 +214,9 @@ impl Market {
             }
         };
 
-        quote_lots as i64
+        std::cmp::min(self.max_quote_lots() as u64, quote_lots)
+            .try_into()
+            .unwrap()
     }
 
     /// Convert from the price stored on the book to the price used in value calculations

--- a/programs/openbook-v2/tests/cases/mod.rs
+++ b/programs/openbook-v2/tests/cases/mod.rs
@@ -17,6 +17,7 @@ mod test_crank;
 mod test_edit_order;
 mod test_fees;
 mod test_indexer;
+mod test_multiple_orders;
 mod test_oracle_peg;
 mod test_order_types;
 mod test_permissioned;

--- a/programs/openbook-v2/tests/cases/test_multiple_orders.rs
+++ b/programs/openbook-v2/tests/cases/test_multiple_orders.rs
@@ -125,8 +125,12 @@ async fn insufficient_funds() -> Result<(), TransportError> {
 
     assert_eq!(position.asks_base_lots, 35);
     assert_eq!(position.bids_base_lots, 0);
+
     assert_eq!(position.base_free_native, 0);
     assert_eq!(position.quote_free_native, 0);
+
+    assert_eq!(solana.token_account_balance(owner_token_0).await, 0);
+    assert_eq!(solana.token_account_balance(owner_token_1).await, 0);
 
     Ok(())
 }

--- a/programs/openbook-v2/tests/cases/test_multiple_orders.rs
+++ b/programs/openbook-v2/tests/cases/test_multiple_orders.rs
@@ -1,26 +1,4 @@
 use super::*;
-use solana_program::program_pack::Pack;
-
-#[allow(clippy::await_holding_refcell_ref)]
-async fn set_balance(solana: &SolanaCookie, pubkey: Pubkey, amount: u64) {
-    let mut account = solana
-        .context
-        .borrow_mut()
-        .banks_client
-        .get_account(pubkey)
-        .await
-        .unwrap()
-        .unwrap();
-
-    let mut account_data = spl_token::state::Account::unpack(&account.data).unwrap();
-    account_data.amount = amount;
-    spl_token::state::Account::pack(account_data, &mut account.data).unwrap();
-
-    solana
-        .context
-        .borrow_mut()
-        .set_account(&pubkey, &account.into());
-}
 
 #[tokio::test]
 async fn insufficient_funds() -> Result<(), TransportError> {
@@ -71,7 +49,7 @@ async fn insufficient_funds() -> Result<(), TransportError> {
     .await
     .unwrap();
 
-    set_balance(solana, owner_token_0, 2_500).await;
+    solana.set_account_balance(owner_token_0, 2_500).await;
 
     // some lamports are already deposited
     send_tx(

--- a/programs/openbook-v2/tests/cases/test_multiple_orders.rs
+++ b/programs/openbook-v2/tests/cases/test_multiple_orders.rs
@@ -50,6 +50,7 @@ async fn insufficient_funds() -> Result<(), TransportError> {
     .unwrap();
 
     solana.set_account_balance(owner_token_0, 2_500).await;
+    solana.set_account_balance(owner_token_1, 101).await;
 
     // some lamports are already deposited
     send_tx(

--- a/programs/openbook-v2/tests/cases/test_multiple_orders.rs
+++ b/programs/openbook-v2/tests/cases/test_multiple_orders.rs
@@ -1,0 +1,153 @@
+use super::*;
+use solana_program::program_pack::Pack;
+
+#[allow(clippy::await_holding_refcell_ref)]
+async fn set_balance(solana: &SolanaCookie, pubkey: Pubkey, amount: u64) {
+    let mut account = solana
+        .context
+        .borrow_mut()
+        .banks_client
+        .get_account(pubkey)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let mut account_data = spl_token::state::Account::unpack(&account.data).unwrap();
+    account_data.amount = amount;
+    spl_token::state::Account::pack(account_data, &mut account.data).unwrap();
+
+    solana
+        .context
+        .borrow_mut()
+        .set_account(&pubkey, &account.into());
+}
+
+#[tokio::test]
+async fn insufficient_funds() -> Result<(), TransportError> {
+    let base_lot_size = 100;
+    let quote_lot_size = 10;
+
+    let TestInitialize {
+        context,
+        owner,
+        owner_token_0,
+        owner_token_1,
+        account_1,
+        account_2,
+        market,
+        market_base_vault,
+        market_quote_vault,
+        ..
+    } = TestContext::new_with_market(TestNewMarketInitialize {
+        base_lot_size,
+        quote_lot_size,
+        ..TestNewMarketInitialize::default()
+    })
+    .await?;
+
+    let solana = &context.solana.clone();
+
+    // there's an ask on the book
+    send_tx(
+        solana,
+        PlaceOrderInstruction {
+            open_orders_account: account_2,
+            open_orders_admin: None,
+            market,
+            signer: owner,
+            user_token_account: owner_token_0,
+            market_vault: market_base_vault,
+            side: Side::Ask,
+            price_lots: 1,
+            max_base_lots: 10,
+            max_quote_lots_including_fees: i64::MAX / 1_000_000,
+            client_order_id: 0,
+            expiry_timestamp: 0,
+            order_type: PlaceOrderType::Limit,
+            self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
+        },
+    )
+    .await
+    .unwrap();
+
+    set_balance(solana, owner_token_0, 2_500).await;
+
+    // some lamports are already deposited
+    send_tx(
+        solana,
+        DepositInstruction {
+            owner,
+            market,
+            open_orders_account: account_1,
+            market_base_vault,
+            market_quote_vault,
+            user_base_account: owner_token_0,
+            user_quote_account: owner_token_1,
+            base_amount: 1_200,
+            quote_amount: 0,
+        },
+    )
+    .await
+    .unwrap();
+
+    // note that a priori, we only have enough lamports to place 2.5 Ask. But as the bid will be
+    // filled & the taker executed immediately, we will have 10 extra base lots available
+    let place_orders = (0..5)
+        .map(|i| {
+            if i == 1 {
+                openbook_v2::PlaceOrderArgs {
+                    side: Side::Bid,
+                    price_lots: 1,
+                    max_base_lots: 10,
+                    max_quote_lots_including_fees: i64::MAX / 1_000_000,
+                    client_order_id: 0,
+                    order_type: PlaceOrderType::Limit,
+                    expiry_timestamp: 0,
+                    self_trade_behavior: SelfTradeBehavior::default(),
+                    limit: 10,
+                }
+            } else {
+                openbook_v2::PlaceOrderArgs {
+                    side: Side::Ask,
+                    price_lots: 1,
+                    max_base_lots: 10,
+                    max_quote_lots_including_fees: i64::MAX / 1_000_000,
+                    client_order_id: 0,
+                    order_type: PlaceOrderType::Limit,
+                    expiry_timestamp: 0,
+                    self_trade_behavior: SelfTradeBehavior::default(),
+                    limit: 10,
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    send_tx(
+        solana,
+        CancelAndPlaceOrdersInstruction {
+            open_orders_account: account_1,
+            open_orders_admin: None,
+            market,
+            signer: owner,
+            user_base_account: owner_token_0,
+            user_quote_account: owner_token_1,
+            cancel_client_orders_ids: vec![],
+            place_orders,
+        },
+    )
+    .await
+    .unwrap();
+
+    let position = solana
+        .get_account::<OpenOrdersAccount>(account_1)
+        .await
+        .position;
+
+    assert_eq!(position.asks_base_lots, 35);
+    assert_eq!(position.bids_base_lots, 0);
+    assert_eq!(position.base_free_native, 0);
+    assert_eq!(position.quote_free_native, 0);
+
+    Ok(())
+}

--- a/programs/openbook-v2/tests/program_test/solana.rs
+++ b/programs/openbook-v2/tests/program_test/solana.rs
@@ -263,6 +263,25 @@ impl SolanaCookie {
         self.get_account::<TokenAccount>(address).await.amount
     }
 
+    pub async fn set_account_balance(&self, address: Pubkey, amount: u64) {
+        let mut account = self
+            .context
+            .borrow_mut()
+            .banks_client
+            .get_account(address)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let mut account_data = spl_token::state::Account::unpack(&account.data).unwrap();
+        account_data.amount = amount;
+        spl_token::state::Account::pack(account_data, &mut account.data).unwrap();
+
+        self.context
+            .borrow_mut()
+            .set_account(&address, &account.into());
+    }
+
     pub fn program_log(&self) -> Vec<String> {
         self.last_transaction_log.borrow().clone()
     }


### PR DESCRIPTION
**problem**

in the current implementation, if the user doesn't have enough funds, during `cancel_and_place_orders` an spl-transfer error will be raised failing the entire tx

**solution**
treat the input lots as an upper limit rather than as an exact amount;  `max_base_lots` and `max_quote_lots_including_fees` are overridden with the user maximum amounts available