### PR TITLE
Add bids_quote_lots to ooa

### DIFF
--- a/programs/openbook-v2/fuzz/Cargo.lock
+++ b/programs/openbook-v2/fuzz/Cargo.lock
@@ -2246,6 +2246,7 @@ dependencies = [
  "pyth-sdk-solana",
  "raydium-amm-v3",
  "solana-program",
+ "solana-security-txt",
  "static_assertions",
  "switchboard-program",
  "switchboard-v2",
@@ -3557,6 +3558,12 @@ dependencies = [
  "rustversion",
  "syn 2.0.31",
 ]
+
+[[package]]
+name = "solana-security-txt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-stake-program"

--- a/programs/openbook-v2/fuzz/fuzz_targets/multiple_orders.rs
+++ b/programs/openbook-v2/fuzz/fuzz_targets/multiple_orders.rs
@@ -368,6 +368,7 @@ fn run_fuzz(fuzz_data: FuzzData) -> Corpus {
             };
 
             assert_eq!(position.bids_base_lots, 0);
+            assert_eq!(position.bids_quote_lots, 0);
             assert_eq!(position.asks_base_lots, 0);
             assert_eq!(position.base_free_native, 0);
             assert_eq!(position.quote_free_native, 0);

--- a/programs/openbook-v2/src/instructions/close_open_orders_account.rs
+++ b/programs/openbook-v2/src/instructions/close_open_orders_account.rs
@@ -6,7 +6,7 @@ pub fn close_open_orders_account(ctx: Context<CloseOpenOrdersAccount>) -> Result
     let open_orders_account = ctx.accounts.open_orders_account.load()?;
 
     require!(
-        open_orders_account.position.is_empty(),
+        open_orders_account.position.is_empty(open_orders_account.version),
         OpenBookError::NonEmptyOpenOrdersPosition
     );
 

--- a/programs/openbook-v2/src/instructions/close_open_orders_account.rs
+++ b/programs/openbook-v2/src/instructions/close_open_orders_account.rs
@@ -6,7 +6,9 @@ pub fn close_open_orders_account(ctx: Context<CloseOpenOrdersAccount>) -> Result
     let open_orders_account = ctx.accounts.open_orders_account.load()?;
 
     require!(
-        open_orders_account.position.is_empty(open_orders_account.version),
+        open_orders_account
+            .position
+            .is_empty(open_orders_account.version),
         OpenBookError::NonEmptyOpenOrdersPosition
     );
 

--- a/programs/openbook-v2/src/instructions/create_open_orders_account.rs
+++ b/programs/openbook-v2/src/instructions/create_open_orders_account.rs
@@ -21,6 +21,7 @@ pub fn create_open_orders_account(
     account.bump = *ctx.bumps.get("open_orders_account").unwrap();
     account.owner = ctx.accounts.owner.key();
     account.delegate = ctx.accounts.delegate_account.non_zero_key();
+    account.version = 1;
     account.open_orders = [OpenOrder::default(); MAX_OPEN_ORDERS];
 
     Ok(())

--- a/programs/openbook-v2/src/logs.rs
+++ b/programs/openbook-v2/src/logs.rs
@@ -83,6 +83,8 @@ pub struct OpenOrdersPositionLog {
     pub market: Pubkey,
     /// Base lots in open bids
     pub bids_base_lots: i64,
+    /// Quote lots in open bids
+    pub bids_quote_lots: i64,
     /// Base lots in open asks
     pub asks_base_lots: i64,
     pub base_free_native: u64,

--- a/programs/openbook-v2/src/state/open_orders_account.rs
+++ b/programs/openbook-v2/src/state/open_orders_account.rs
@@ -345,13 +345,16 @@ pub struct Position {
     /// Quote lots in open bids
     pub bids_quote_lots: i64,
 
+    // Introducing a version as we are adding a new field bids_quote_lots
+    pub version: u8,
+
     #[derivative(Debug = "ignore")]
-    pub reserved: [u8; 64],
+    pub reserved: [u8; 63],
 }
 
 const_assert_eq!(
     size_of::<Position>(),
-    8 + 8 + 8 + 8 + 8 + 8 + 8 + 16 + 16 + 72
+    8 + 8 + 8 + 8 + 8 + 8 + 8 + 16 + 16 + 8 + 1 + 63
 );
 const_assert_eq!(size_of::<Position>(), 160);
 const_assert_eq!(size_of::<Position>() % 8, 0);
@@ -369,7 +372,8 @@ impl Default for Position {
             maker_volume: 0,
             taker_volume: 0,
             bids_quote_lots: 0,
-            reserved: [0; 64],
+            version: 1,
+            reserved: [0; 63],
         }
     }
 }
@@ -391,7 +395,8 @@ impl Position {
             && self.locked_maker_fees == 0
             && self.referrer_rebates_available == 0
             && self.penalty_heap_count == 0
-            && self.bids_quote_lots == 0
+            // For version 0, bids_quote_lots was not properly tracked
+            && (self.version == 0 || self.bids_quote_lots == 0)
     }
 }
 

--- a/programs/openbook-v2/src/state/orderbook/mod.rs
+++ b/programs/openbook-v2/src/state/orderbook/mod.rs
@@ -285,6 +285,7 @@ mod tests {
         ));
         assert!(order_tree_contains_price(&book.bids, price_lots as u64));
         assert_eq!(maker.position.bids_base_lots, bid_quantity);
+        assert_eq!(maker.position.bids_quote_lots, bid_quantity * price_lots);
         assert_eq!(maker.position.asks_base_lots, 0);
         assert_eq!(event_heap.len(), 0);
 
@@ -330,6 +331,7 @@ mod tests {
         // the taker account is updated
         assert!(taker.open_order_by_raw_index(1).is_free());
         assert_eq!(taker.position.bids_base_lots, 0);
+        assert_eq!(taker.position.bids_quote_lots, 0);
         assert_eq!(taker.position.asks_base_lots, 0);
         // the fill gets added to the event heap
         assert_eq!(event_heap.len(), 1);
@@ -350,6 +352,7 @@ mod tests {
         assert_eq!(maker.position.asks_base_lots, 0);
 
         assert_eq!(taker.position.bids_base_lots, 0);
+        assert_eq!(taker.position.bids_quote_lots, 0);
         assert_eq!(taker.position.asks_base_lots, 0);
         // Maker fee is accrued now
         assert_eq!(

--- a/programs/openbook-v2/tests/cases/test_oracle_peg.rs
+++ b/programs/openbook-v2/tests/cases/test_oracle_peg.rs
@@ -254,26 +254,6 @@ async fn test_oracle_peg() -> Result<(), TransportError> {
 
     assert_no_orders(solana, account_1).await;
 
-    // TEST: Place a pegged order and check how it behaves with oracle changes
-    send_tx(
-        solana,
-        PlaceOrderPeggedInstruction {
-            open_orders_account: account_1,
-            market,
-            signer: owner,
-            user_token_account: owner_token_1,
-            market_vault: market_quote_vault,
-            side: Side::Bid,
-            price_offset: -1,
-            peg_limit: 1,
-            max_base_lots: 2,
-            max_quote_lots_including_fees: 100_000,
-            client_order_id: 5,
-        },
-    )
-    .await
-    .unwrap();
-
     // TEST: an ask at current oracle price does not match
     send_tx(
         solana,

--- a/programs/openbook-v2/tests/cases/test_oracle_peg.rs
+++ b/programs/openbook-v2/tests/cases/test_oracle_peg.rs
@@ -777,6 +777,133 @@ async fn test_locked_amounts() -> Result<(), TransportError> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_bids_quote_lots() -> Result<(), TransportError> {
+    let quote_lot_size = 10;
+    let base_lot_size = 100;
+    let maker_fee = 200;
+    let taker_fee = 400;
+
+    let TestInitialize {
+        context,
+        owner,
+        owner_token_0: owner_base_ata,
+        owner_token_1: owner_quote_ata,
+        market,
+
+        market_base_vault,
+        market_quote_vault,
+        account_1,
+        account_2,
+        ..
+    } = TestContext::new_with_market(TestNewMarketInitialize {
+        quote_lot_size,
+        base_lot_size,
+        maker_fee,
+        taker_fee,
+        ..TestNewMarketInitialize::default()
+    })
+    .await?;
+    let solana = &context.solana.clone();
+
+    send_tx(
+        solana,
+        PlaceOrderPeggedInstruction {
+            open_orders_account: account_1,
+            market,
+            signer: owner,
+            user_token_account: owner_quote_ata,
+            market_vault: market_quote_vault,
+            side: Side::Bid,
+            price_offset: 0,
+            peg_limit: 20,
+            max_base_lots: 100,
+            max_quote_lots_including_fees: 100_000_000,
+            client_order_id: 0,
+        },
+    )
+    .await
+    .unwrap();
+
+    // first partial match with another oracle peg order
+    send_tx(
+        solana,
+        PlaceOrderPeggedInstruction {
+            open_orders_account: account_2,
+            market,
+            signer: owner,
+            user_token_account: owner_base_ata,
+            market_vault: market_base_vault,
+            side: Side::Ask,
+            price_offset: 0,
+            peg_limit: 20,
+            max_base_lots: 30,
+            max_quote_lots_including_fees: 100_000_000,
+            client_order_id: 0,
+        },
+    )
+    .await
+    .unwrap();
+
+    // not yet unlocked!
+    let oo_1 = solana.get_account::<OpenOrdersAccount>(account_1).await;
+    assert_eq!(oo_1.position.bids_quote_lots, 2_000);
+
+    send_tx(
+        solana,
+        ConsumeEventsInstruction {
+            consume_events_admin: None,
+            market,
+            open_orders_accounts: vec![account_1, account_2],
+        },
+    )
+    .await
+    .unwrap();
+
+    let oo_1 = solana.get_account::<OpenOrdersAccount>(account_1).await;
+    assert_eq!(oo_1.position.bids_quote_lots, 1_400);
+
+    // and fill the rest of the order with a normal ask
+    send_tx(
+        solana,
+        PlaceOrderInstruction {
+            open_orders_account: account_2,
+            open_orders_admin: None,
+            market,
+            signer: owner,
+            user_token_account: owner_base_ata,
+            market_vault: market_base_vault,
+            side: Side::Ask,
+            price_lots: 1,
+            max_base_lots: 70,
+            max_quote_lots_including_fees: 100_000_000,
+            client_order_id: 0,
+            expiry_timestamp: 0,
+            order_type: PlaceOrderType::Limit,
+            self_trade_behavior: SelfTradeBehavior::default(),
+            remainings: vec![],
+        },
+    )
+    .await
+    .unwrap();
+
+    send_tx(
+        solana,
+        ConsumeEventsInstruction {
+            consume_events_admin: None,
+            market,
+            open_orders_accounts: vec![account_1, account_2],
+        },
+    )
+    .await
+    .unwrap();
+
+    let oo_1 = solana.get_account::<OpenOrdersAccount>(account_1).await;
+    assert_eq!(oo_1.position.bids_quote_lots, 0);
+
+    Ok(())
+}
+
 async fn assert_no_orders(solana: &SolanaCookie, account_1: Pubkey) {
     let open_orders_account = solana.get_account::<OpenOrdersAccount>(account_1).await;
 


### PR DESCRIPTION
In order to simplify accounting for MM, they should know the quote amount present on the book by querying only the ooa