### PR TITLE
quoteLotsToUiConverter pass correct quote decimals

### DIFF
--- a/ts/client/src/market.ts
+++ b/ts/client/src/market.ts
@@ -137,7 +137,7 @@ function baseLotsToUiConverter(market: MarketAccount): number {
 }
 function quoteLotsToUiConverter(market: MarketAccount): number {
   return new Big(market.quoteLotSize.toString())
-    .div(new Big(10).pow(QUOTE_DECIMALS))
+    .div(new Big(10).pow(market.quoteDecimals))
     .toNumber();
 }
 


### PR DESCRIPTION
quoteLotsToUiConverter taking a constant QUOTE_DECIMALS which assumed quote token decimals were 6, instead of fetching actual quoteDecimals from MarketAccount.