### PR TITLE
Do not allow penalty payer to be null in settle funds in ts client

### DIFF
--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -955,7 +955,7 @@ export class OpenBookV2Client {
     market: MarketAccount,
     userBaseAccount: PublicKey,
     userQuoteAccount: PublicKey,
-    referrerAccount: PublicKey | null,
+    referrerAccount: PublicKey,
     penaltyPayer: PublicKey | null,
     openOrdersDelegate?: Keypair,
   ): Promise<[TransactionInstruction, Signer[]]> {

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -955,8 +955,8 @@ export class OpenBookV2Client {
     market: MarketAccount,
     userBaseAccount: PublicKey,
     userQuoteAccount: PublicKey,
-    referrerAccount: PublicKey,
-    penaltyPayer: PublicKey | null,
+    referrerAccount: PublicKey | null,
+    penaltyPayer: PublicKey,
     openOrdersDelegate?: Keypair,
   ): Promise<[TransactionInstruction, Signer[]]> {
     const ix = await this.program.methods

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -973,7 +973,7 @@ export class OpenBookV2Client {
         userBaseAccount: userBaseAccount,
         userQuoteAccount: userQuoteAccount,
         referrerAccount: referrerAccount,
-        penaltyPayer: penaltyPayer ?? PublicKey.default,
+        penaltyPayer: penaltyPayer,
       })
       .instruction();
 


### PR DESCRIPTION
The program requires it as a signer.
https://github.com/openbook-dex/openbook-v2/blob/master/programs/openbook-v2/src/accounts_ix/settle_funds.rs#L11

The default key that the client otherwise uses does not work because the web3.js client fails signature validation in preflight.