### PR TITLE
cancel by client_id iterates and fails silently

### DIFF
--- a/idl/openbook_v2.json
+++ b/idl/openbook_v2.json
@@ -3239,7 +3239,7 @@
             "name": "ImmediateOrCancel",
             "fields": [
               {
-                "name": "priceLots",
+                "name": "price_lots",
                 "type": "i64"
               }
             ]
@@ -3248,11 +3248,11 @@
             "name": "Fixed",
             "fields": [
               {
-                "name": "priceLots",
+                "name": "price_lots",
                 "type": "i64"
               },
               {
-                "name": "orderType",
+                "name": "order_type",
                 "type": {
                   "defined": "PostOrderType"
                 }
@@ -3263,17 +3263,17 @@
             "name": "OraclePegged",
             "fields": [
               {
-                "name": "priceOffsetLots",
+                "name": "price_offset_lots",
                 "type": "i64"
               },
               {
-                "name": "orderType",
+                "name": "order_type",
                 "type": {
                   "defined": "PostOrderType"
                 }
               },
               {
-                "name": "pegLimit",
+                "name": "peg_limit",
                 "type": "i64"
               }
             ]
@@ -3293,13 +3293,6 @@
             "name": "Asks"
           }
         ]
-      }
-    },
-    {
-      "name": "NodeHandle",
-      "type": {
-        "kind": "alias",
-        "value": "u32"
       }
     }
   ],

--- a/idl/openbook_v2.json
+++ b/idl/openbook_v2.json
@@ -1635,12 +1635,7 @@
           "isSigner": false
         }
       ],
-      "args": [
-        {
-          "name": "limit",
-          "type": "u8"
-        }
-      ]
+      "args": []
     },
     {
       "name": "stubOracleCreate",
@@ -3244,7 +3239,7 @@
             "name": "ImmediateOrCancel",
             "fields": [
               {
-                "name": "price_lots",
+                "name": "priceLots",
                 "type": "i64"
               }
             ]
@@ -3253,11 +3248,11 @@
             "name": "Fixed",
             "fields": [
               {
-                "name": "price_lots",
+                "name": "priceLots",
                 "type": "i64"
               },
               {
-                "name": "order_type",
+                "name": "orderType",
                 "type": {
                   "defined": "PostOrderType"
                 }
@@ -3268,17 +3263,17 @@
             "name": "OraclePegged",
             "fields": [
               {
-                "name": "price_offset_lots",
+                "name": "priceOffsetLots",
                 "type": "i64"
               },
               {
-                "name": "order_type",
+                "name": "orderType",
                 "type": {
                   "defined": "PostOrderType"
                 }
               },
               {
-                "name": "peg_limit",
+                "name": "pegLimit",
                 "type": "i64"
               }
             ]
@@ -3298,6 +3293,13 @@
             "name": "Asks"
           }
         ]
+      }
+    },
+    {
+      "name": "NodeHandle",
+      "type": {
+        "kind": "alias",
+        "value": "u32"
       }
     }
   ],

--- a/programs/openbook-v2/src/instructions/cancel_all_and_place_orders.rs
+++ b/programs/openbook-v2/src/instructions/cancel_all_and_place_orders.rs
@@ -41,7 +41,7 @@ pub fn cancel_all_and_place_orders(
     )?;
 
     if cancel {
-        book.cancel_all_orders(&mut open_orders_account, *market, u8::MAX, None)?;
+        book.cancel_all_orders(&mut open_orders_account, *market, u8::MAX, None, None)?;
     }
 
     let mut base_amount = 0_u64;

--- a/programs/openbook-v2/src/instructions/cancel_all_orders.rs
+++ b/programs/openbook-v2/src/instructions/cancel_all_orders.rs
@@ -16,7 +16,7 @@ pub fn cancel_all_orders(
         asks: ctx.accounts.asks.load_mut()?,
     };
 
-    book.cancel_all_orders(&mut account, *market, limit, side_option)?;
+    book.cancel_all_orders(&mut account, *market, limit, side_option, None)?;
 
     Ok(())
 }

--- a/programs/openbook-v2/src/instructions/cancel_order_by_client_order_id.rs
+++ b/programs/openbook-v2/src/instructions/cancel_order_by_client_order_id.rs
@@ -1,7 +1,6 @@
 use anchor_lang::prelude::*;
 
 use crate::accounts_ix::*;
-use crate::error::*;
 use crate::state::*;
 
 pub fn cancel_order_by_client_order_id(
@@ -9,17 +8,6 @@ pub fn cancel_order_by_client_order_id(
     client_order_id: u64,
 ) -> Result<i64> {
     let mut account = ctx.accounts.open_orders_account.load_mut()?;
-    let oo = account
-        .find_order_with_client_order_id(client_order_id)
-        .ok_or_else(|| {
-            error_msg_typed!(
-                OpenBookError::OpenOrdersOrderNotFound,
-                "client order id = {client_order_id}"
-            )
-        })?;
-
-    let order_id = oo.id;
-    let order_side_and_tree = oo.side_and_tree();
 
     let market = ctx.accounts.market.load()?;
     let mut book = Orderbook {
@@ -27,15 +15,5 @@ pub fn cancel_order_by_client_order_id(
         asks: ctx.accounts.asks.load_mut()?,
     };
 
-    let leaf_node_quantity = book
-        .cancel_order(
-            &mut account,
-            order_id,
-            order_side_and_tree,
-            *market,
-            Some(ctx.accounts.open_orders_account.key()),
-        )?
-        .quantity;
-
-    Ok(leaf_node_quantity)
+    return book.cancel_all_orders(&mut account, *market, u8::MAX, None, Some(client_order_id));
 }

--- a/programs/openbook-v2/src/instructions/cancel_order_by_client_order_id.rs
+++ b/programs/openbook-v2/src/instructions/cancel_order_by_client_order_id.rs
@@ -15,5 +15,5 @@ pub fn cancel_order_by_client_order_id(
         asks: ctx.accounts.asks.load_mut()?,
     };
 
-    return book.cancel_all_orders(&mut account, *market, u8::MAX, None, Some(client_order_id));
+    book.cancel_all_orders(&mut account, *market, u8::MAX, None, Some(client_order_id))
 }

--- a/programs/openbook-v2/src/instructions/prune_orders.rs
+++ b/programs/openbook-v2/src/instructions/prune_orders.rs
@@ -4,7 +4,7 @@ use crate::accounts_ix::*;
 use crate::error::*;
 use crate::state::*;
 
-pub fn prune_orders(ctx: Context<PruneOrders>, limit: u8) -> Result<()> {
+pub fn prune_orders(ctx: Context<PruneOrders>) -> Result<()> {
     let mut account = ctx.accounts.open_orders_account.load_mut()?;
     let market = ctx.accounts.market.load()?;
 
@@ -18,7 +18,7 @@ pub fn prune_orders(ctx: Context<PruneOrders>, limit: u8) -> Result<()> {
         asks: ctx.accounts.asks.load_mut()?,
     };
 
-    book.cancel_all_orders(&mut account, *market, limit, None)?;
+    book.cancel_all_orders(&mut account, *market, u8::MAX, None, None)?;
 
     Ok(())
 }

--- a/programs/openbook-v2/src/lib.rs
+++ b/programs/openbook-v2/src/lib.rs
@@ -569,9 +569,9 @@ pub mod openbook_v2 {
 
     /// Remove orders from the book when the market is expired (only
     /// [`close_market_admin`](crate::state::Market::close_market_admin)).
-    pub fn prune_orders(ctx: Context<PruneOrders>, limit: u8) -> Result<()> {
+    pub fn prune_orders(ctx: Context<PruneOrders>) -> Result<()> {
         #[cfg(feature = "enable-gpl")]
-        instructions::prune_orders(ctx, limit)?;
+        instructions::prune_orders(ctx)?;
         Ok(())
     }
 

--- a/programs/openbook-v2/src/state/orderbook/book.rs
+++ b/programs/openbook-v2/src/state/orderbook/book.rs
@@ -485,6 +485,7 @@ impl<'a> Orderbook<'a> {
         market: Market,
         mut limit: u8,
         side_to_cancel_option: Option<Side>,
+        client_id_option: Option<u64>,
     ) -> Result<i64> {
         let mut total_quantity = 0_i64;
         for i in 0..MAX_OPEN_ORDERS {
@@ -496,6 +497,12 @@ impl<'a> Orderbook<'a> {
             let order_side_and_tree = oo.side_and_tree();
             if let Some(side_to_cancel) = side_to_cancel_option {
                 if side_to_cancel != order_side_and_tree.side() {
+                    continue;
+                }
+            }
+
+            if let Some(client_id) = client_id_option {
+                if client_id != oo.client_id {
                     continue;
                 }
             }

--- a/programs/openbook-v2/tests/cases/test_edit_order.rs
+++ b/programs/openbook-v2/tests/cases/test_edit_order.rs
@@ -56,8 +56,8 @@ async fn test_edit_order() -> Result<(), TransportError> {
         assert_eq!(open_orders_account_1.position.asks_base_lots, 0);
     }
 
-    // No client Id found
-    assert!(send_tx(
+    // No client Id found, is treated as if order was fully filled
+    send_tx(
         solana,
         EditOrderInstruction {
             open_orders_account: account_1,
@@ -79,7 +79,7 @@ async fn test_edit_order() -> Result<(), TransportError> {
         },
     )
     .await
-    .is_err());
+    .unwrap();
 
     // take 1. send remaining to crank and remove 1 bids_base_lots
     send_tx(

--- a/programs/openbook-v2/tests/cases/test_oracle_peg.rs
+++ b/programs/openbook-v2/tests/cases/test_oracle_peg.rs
@@ -375,17 +375,11 @@ async fn test_oracle_peg() -> Result<(), TransportError> {
     )
     .await
     .unwrap();
-    assert!(send_tx(
-        solana,
-        CancelOrderByClientOrderIdInstruction {
-            open_orders_account: account_2,
-            market,
-            signer: owner,
-            client_order_id: 62,
-        },
-    )
-    .await
-    .is_err());
+
+    {
+        let oo = solana.get_account::<OpenOrdersAccount>(account_2).await;
+        assert!(oo.find_order_with_client_order_id(62).is_none());
+    }
 
     // but once the adjusted price is > the peg limit, it's gone
     set_stub_oracle_price(solana, &tokens[0], collect_fee_admin, 1.004).await;

--- a/programs/openbook-v2/tests/program_test/client.rs
+++ b/programs/openbook-v2/tests/program_test/client.rs
@@ -1189,7 +1189,7 @@ impl ClientInstruction for PruneOrdersInstruction {
         account_loader: impl ClientAccountLoader + 'async_trait,
     ) -> (Self::Accounts, instruction::Instruction) {
         let program_id = openbook_v2::id();
-        let instruction = Self::Instruction { limit: 5 };
+        let instruction = Self::Instruction { };
         let market: Market = account_loader.load(&self.market).await.unwrap();
 
         let accounts = Self::Accounts {

--- a/programs/openbook-v2/tests/program_test/client.rs
+++ b/programs/openbook-v2/tests/program_test/client.rs
@@ -1189,7 +1189,7 @@ impl ClientInstruction for PruneOrdersInstruction {
         account_loader: impl ClientAccountLoader + 'async_trait,
     ) -> (Self::Accounts, instruction::Instruction) {
         let program_id = openbook_v2::id();
-        let instruction = Self::Instruction { };
+        let instruction = Self::Instruction {};
         let market: Market = account_loader.load(&self.market).await.unwrap();
 
         let accounts = Self::Accounts {

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -428,7 +428,7 @@ export class OpenBookV2Client {
   ): Promise<[TransactionInstruction[], PublicKey]> {
     const ixs: TransactionInstruction[] = [];
     let accountIndex = new BN(1);
-    
+
     if (openOrdersIndexer == null)
       openOrdersIndexer = this.findOpenOrdersIndexer(owner);
 
@@ -444,9 +444,7 @@ export class OpenBookV2Client {
         accountIndex = new BN(storedIndexer.createdCounter + 1);
       }
     } catch {
-      ixs.push(
-        await this.createOpenOrdersIndexerIx(openOrdersIndexer, owner),
-      );
+      ixs.push(await this.createOpenOrdersIndexerIx(openOrdersIndexer, owner));
     }
 
     const openOrdersAccount = this.findOpenOrderAtIndex(owner, accountIndex);
@@ -1066,11 +1064,10 @@ export class OpenBookV2Client {
     marketPublicKey: PublicKey,
     market: MarketAccount,
     openOrdersPublicKey: PublicKey,
-    limit: number,
     closeMarketAdmin: Keypair | null = null,
   ): Promise<[TransactionInstruction, Signer[]]> {
     const ix = await this.program.methods
-      .pruneOrders(limit)
+      .pruneOrders()
       .accounts({
         closeMarketAdmin: market.closeMarketAdmin.key,
         openOrdersAccount: openOrdersPublicKey,

--- a/ts/client/src/openbook_v2.ts
+++ b/ts/client/src/openbook_v2.ts
@@ -3086,7 +3086,7 @@ export type OpenbookV2 = {
             name: 'ImmediateOrCancel';
             fields: [
               {
-                name: 'priceLots';
+                name: 'price_lots';
                 type: 'i64';
               },
             ];
@@ -3095,11 +3095,11 @@ export type OpenbookV2 = {
             name: 'Fixed';
             fields: [
               {
-                name: 'priceLots';
+                name: 'price_lots';
                 type: 'i64';
               },
               {
-                name: 'orderType';
+                name: 'order_type';
                 type: {
                   defined: 'PostOrderType';
                 };
@@ -3110,17 +3110,17 @@ export type OpenbookV2 = {
             name: 'OraclePegged';
             fields: [
               {
-                name: 'priceOffsetLots';
+                name: 'price_offset_lots';
                 type: 'i64';
               },
               {
-                name: 'orderType';
+                name: 'order_type';
                 type: {
                   defined: 'PostOrderType';
                 };
               },
               {
-                name: 'pegLimit';
+                name: 'peg_limit';
                 type: 'i64';
               },
             ];
@@ -3140,13 +3140,6 @@ export type OpenbookV2 = {
             name: 'Asks';
           },
         ];
-      };
-    },
-    {
-      name: 'NodeHandle';
-      type: {
-        kind: 'alias';
-        value: 'u32';
       };
     },
   ];
@@ -6773,7 +6766,7 @@ export const IDL: OpenbookV2 = {
             name: 'ImmediateOrCancel',
             fields: [
               {
-                name: 'priceLots',
+                name: 'price_lots',
                 type: 'i64',
               },
             ],
@@ -6782,11 +6775,11 @@ export const IDL: OpenbookV2 = {
             name: 'Fixed',
             fields: [
               {
-                name: 'priceLots',
+                name: 'price_lots',
                 type: 'i64',
               },
               {
-                name: 'orderType',
+                name: 'order_type',
                 type: {
                   defined: 'PostOrderType',
                 },
@@ -6797,17 +6790,17 @@ export const IDL: OpenbookV2 = {
             name: 'OraclePegged',
             fields: [
               {
-                name: 'priceOffsetLots',
+                name: 'price_offset_lots',
                 type: 'i64',
               },
               {
-                name: 'orderType',
+                name: 'order_type',
                 type: {
                   defined: 'PostOrderType',
                 },
               },
               {
-                name: 'pegLimit',
+                name: 'peg_limit',
                 type: 'i64',
               },
             ],
@@ -6827,13 +6820,6 @@ export const IDL: OpenbookV2 = {
             name: 'Asks',
           },
         ],
-      },
-    },
-    {
-      name: 'NodeHandle',
-      type: {
-        kind: 'alias',
-        value: 'u32',
       },
     },
   ],

--- a/ts/client/src/openbook_v2.ts
+++ b/ts/client/src/openbook_v2.ts
@@ -1,4 +1,4 @@
-export interface OpenbookV2 {
+export type OpenbookV2 = {
   version: '0.1.0';
   name: 'openbook_v2';
   instructions: [
@@ -1619,12 +1619,7 @@ export interface OpenbookV2 {
           isSigner: false;
         },
       ];
-      args: [
-        {
-          name: 'limit';
-          type: 'u8';
-        },
-      ];
+      args: [];
     },
     {
       name: 'stubOracleCreate';
@@ -3091,7 +3086,7 @@ export interface OpenbookV2 {
             name: 'ImmediateOrCancel';
             fields: [
               {
-                name: 'price_lots';
+                name: 'priceLots';
                 type: 'i64';
               },
             ];
@@ -3100,11 +3095,11 @@ export interface OpenbookV2 {
             name: 'Fixed';
             fields: [
               {
-                name: 'price_lots';
+                name: 'priceLots';
                 type: 'i64';
               },
               {
-                name: 'order_type';
+                name: 'orderType';
                 type: {
                   defined: 'PostOrderType';
                 };
@@ -3115,17 +3110,17 @@ export interface OpenbookV2 {
             name: 'OraclePegged';
             fields: [
               {
-                name: 'price_offset_lots';
+                name: 'priceOffsetLots';
                 type: 'i64';
               },
               {
-                name: 'order_type';
+                name: 'orderType';
                 type: {
                   defined: 'PostOrderType';
                 };
               },
               {
-                name: 'peg_limit';
+                name: 'pegLimit';
                 type: 'i64';
               },
             ];
@@ -3145,6 +3140,13 @@ export interface OpenbookV2 {
             name: 'Asks';
           },
         ];
+      };
+    },
+    {
+      name: 'NodeHandle';
+      type: {
+        kind: 'alias';
+        value: 'u32';
       };
     },
   ];
@@ -3681,7 +3683,7 @@ export interface OpenbookV2 {
       msg: 'Cannot close a non-empty open orders account';
     },
   ];
-}
+};
 
 export const IDL: OpenbookV2 = {
   version: '0.1.0',
@@ -5304,12 +5306,7 @@ export const IDL: OpenbookV2 = {
           isSigner: false,
         },
       ],
-      args: [
-        {
-          name: 'limit',
-          type: 'u8',
-        },
-      ],
+      args: [],
     },
     {
       name: 'stubOracleCreate',
@@ -6776,7 +6773,7 @@ export const IDL: OpenbookV2 = {
             name: 'ImmediateOrCancel',
             fields: [
               {
-                name: 'price_lots',
+                name: 'priceLots',
                 type: 'i64',
               },
             ],
@@ -6785,11 +6782,11 @@ export const IDL: OpenbookV2 = {
             name: 'Fixed',
             fields: [
               {
-                name: 'price_lots',
+                name: 'priceLots',
                 type: 'i64',
               },
               {
-                name: 'order_type',
+                name: 'orderType',
                 type: {
                   defined: 'PostOrderType',
                 },
@@ -6800,17 +6797,17 @@ export const IDL: OpenbookV2 = {
             name: 'OraclePegged',
             fields: [
               {
-                name: 'price_offset_lots',
+                name: 'priceOffsetLots',
                 type: 'i64',
               },
               {
-                name: 'order_type',
+                name: 'orderType',
                 type: {
                   defined: 'PostOrderType',
                 },
               },
               {
-                name: 'peg_limit',
+                name: 'pegLimit',
                 type: 'i64',
               },
             ],
@@ -6830,6 +6827,13 @@ export const IDL: OpenbookV2 = {
             name: 'Asks',
           },
         ],
+      },
+    },
+    {
+      name: 'NodeHandle',
+      type: {
+        kind: 'alias',
+        value: 'u32',
       },
     },
   ],

--- a/ts/client/src/test/market.ts
+++ b/ts/client/src/test/market.ts
@@ -33,7 +33,7 @@ async function testFindAllMarkets(): Promise<void> {
 async function testDecodeMarket(): Promise<void> {
   const client = initReadOnlyOpenbookClient();
   const marketPk = new PublicKey(
-    'CFSMrBssNG8Ud1edW59jNLnq2cwrQ9uY5cM3wXmqRJj3',
+    '8wjNUxS1oQpu6YXnG85WBBJtUNH29p8cXdjP4nFqrJTo',
   );
   const market = await Market.load(client, marketPk);
   await market.loadOrderBook();
@@ -61,5 +61,5 @@ async function testWatchMarket(): Promise<void> {
 
 // void testFindAccountsByMints();
 // void testFindAllMarkets();
-// void testDecodeMarket();
-void testWatchMarket();
+void testDecodeMarket();
+// void testWatchMarket();


### PR DESCRIPTION
cancel by client id previously would fail the transaction making it very difficult to implement cancelling a subset of orders (e.g. assigned to an individual trading engine inside a multi strategy fund). if an order is filled while the users transaction is inflight, a direct cancel with a client id can fail if there is no such order.

in my opinion this version is better, it is easier to use

also removed the limit on prune orders, as the OO account is anyways limited to 24 orders, there's not a lot of value in an explicit limit argument.