### PR TITLE
add oracle_price_lots fn

### DIFF
--- a/programs/openbook-v2/src/instructions/cancel_all_and_place_orders.rs
+++ b/programs/openbook-v2/src/instructions/cancel_all_and_place_orders.rs
@@ -34,7 +34,7 @@ pub fn cancel_all_and_place_orders(
 
     let now_ts: u64 = clock.unix_timestamp.try_into().unwrap();
 
-    let oracle_price = market.oracle_price(
+    let oracle_price_lots = market.oracle_price_lots(
         AccountInfoRef::borrow_some(ctx.accounts.oracle_a.as_ref())?.as_ref(),
         AccountInfoRef::borrow_some(ctx.accounts.oracle_b.as_ref())?.as_ref(),
         clock.slot,
@@ -89,7 +89,7 @@ pub fn cancel_all_and_place_orders(
             order,
             &mut market,
             &mut event_heap,
-            oracle_price,
+            oracle_price_lots,
             Some(&mut open_orders_account),
             &open_orders_account_pk,
             now_ts,

--- a/programs/openbook-v2/src/instructions/place_order.rs
+++ b/programs/openbook-v2/src/instructions/place_order.rs
@@ -41,7 +41,7 @@ pub fn place_order(ctx: Context<PlaceOrder>, order: Order, limit: u8) -> Result<
 
     let now_ts: u64 = clock.unix_timestamp.try_into().unwrap();
 
-    let oracle_price = market.oracle_price(
+    let oracle_price_lots = market.oracle_price_lots(
         AccountInfoRef::borrow_some(ctx.accounts.oracle_a.as_ref())?.as_ref(),
         AccountInfoRef::borrow_some(ctx.accounts.oracle_b.as_ref())?.as_ref(),
         clock.slot,
@@ -60,7 +60,7 @@ pub fn place_order(ctx: Context<PlaceOrder>, order: Order, limit: u8) -> Result<
         &order,
         &mut market,
         &mut event_heap,
-        oracle_price,
+        oracle_price_lots,
         Some(&mut open_orders_account),
         &open_orders_account_pk,
         now_ts,

--- a/programs/openbook-v2/src/instructions/place_take_order.rs
+++ b/programs/openbook-v2/src/instructions/place_take_order.rs
@@ -33,7 +33,7 @@ pub fn place_take_order(ctx: Context<PlaceTakeOrder>, order: Order, limit: u8) -
 
     let now_ts: u64 = clock.unix_timestamp.try_into().unwrap();
 
-    let oracle_price = market.oracle_price(
+    let oracle_price_lots = market.oracle_price_lots(
         AccountInfoRef::borrow_some(ctx.accounts.oracle_a.as_ref())?.as_ref(),
         AccountInfoRef::borrow_some(ctx.accounts.oracle_b.as_ref())?.as_ref(),
         clock.slot,
@@ -51,7 +51,7 @@ pub fn place_take_order(ctx: Context<PlaceTakeOrder>, order: Order, limit: u8) -
         &order,
         &mut market,
         &mut event_heap,
-        oracle_price,
+        oracle_price_lots,
         None,
         &ctx.accounts.signer.key(),
         now_ts,

--- a/programs/openbook-v2/src/state/market.rs
+++ b/programs/openbook-v2/src/state/market.rs
@@ -226,6 +226,19 @@ impl Market {
             .ok_or_else(|| OpenBookError::InvalidOraclePrice.into())
     }
 
+    pub fn oracle_price_lots(
+        &self,
+        oracle_a_acc: Option<&impl KeyedAccountReader>,
+        oracle_b_acc: Option<&impl KeyedAccountReader>,
+        slot: u64,
+    ) -> Result<Option<i64>> {
+        let oracle_price = self.oracle_price(oracle_a_acc, oracle_b_acc, slot)?;
+        match oracle_price {
+            Some(p) => Ok(Some(self.native_price_to_lot(p)?)),
+            None => Ok(None),
+        }
+    }
+
     pub fn oracle_price(
         &self,
         oracle_a_acc: Option<&impl KeyedAccountReader>,

--- a/programs/openbook-v2/src/state/orderbook/book.rs
+++ b/programs/openbook-v2/src/state/orderbook/book.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use anchor_lang::prelude::*;
 use bytemuck::cast;
-use fixed::types::I80F48;
 use std::cell::RefMut;
 
 use super::*;
@@ -64,7 +63,7 @@ impl<'a> Orderbook<'a> {
         order: &Order,
         open_book_market: &mut Market,
         event_heap: &mut EventHeap,
-        oracle_price: Option<I80F48>,
+        oracle_price_lots: Option<i64>,
         mut open_orders_account: Option<&mut OpenOrdersAccount>,
         owner: &Pubkey,
         now_ts: u64,
@@ -79,11 +78,6 @@ impl<'a> Orderbook<'a> {
         let post_only = order.is_post_only();
         let fill_or_kill = order.is_fill_or_kill();
         let mut post_target = order.post_target();
-        let oracle_price_lots = if let Some(oracle_price) = oracle_price {
-            Some(market.native_price_to_lot(oracle_price)?)
-        } else {
-            None
-        };
         let (price_lots, price_data) = order.price(now_ts, oracle_price_lots, self)?;
 
         // generate new order id


### PR DESCRIPTION
currently `oracle_price` is converted to `oracle_price_lots` inside book’s new_order

https://github.com/openbook-dex/openbook-v2/blob/706186b299e8a59c639e583f87dbc4e09d996d20/programs/openbook-v2/src/state/orderbook/book.rs#L82

hence, when placing multiple orders, the same (possible costly -i80f48 math-) operation will be repeated several times. This PR makes the calculation before the new_order loop so it's only computed once per ix with the intention of saving some CUs


