### PR TITLE
Lou/logs

### DIFF
--- a/programs/openbook-v2/src/instructions/cancel_all_and_place_orders.rs
+++ b/programs/openbook-v2/src/instructions/cancel_all_and_place_orders.rs
@@ -88,6 +88,7 @@ pub fn cancel_all_and_place_orders(
         } = book.new_order(
             order,
             &mut market,
+            &ctx.accounts.market.key(),
             &mut event_heap,
             oracle_price,
             Some(&mut open_orders_account),

--- a/programs/openbook-v2/src/instructions/deposit.rs
+++ b/programs/openbook-v2/src/instructions/deposit.rs
@@ -1,6 +1,6 @@
 use crate::accounts_ix::Deposit;
 use crate::error::*;
-use crate::logs::DepositLog;
+use crate::logs::{emit_stack, DepositLog};
 use crate::token_utils::*;
 use anchor_lang::prelude::*;
 
@@ -33,7 +33,7 @@ pub fn deposit(ctx: Context<Deposit>, base_amount: u64, quote_amount: u64) -> Re
     market.quote_deposit_total += quote_amount;
 
     if base_amount > 0 || quote_amount > 0 {
-        emit!(DepositLog {
+        emit_stack(DepositLog {
             open_orders_account: ctx.accounts.open_orders_account.key(),
             signer: ctx.accounts.owner.key(),
             base_amount,

--- a/programs/openbook-v2/src/instructions/place_order.rs
+++ b/programs/openbook-v2/src/instructions/place_order.rs
@@ -4,6 +4,7 @@ use std::cmp;
 use crate::accounts_ix::*;
 use crate::accounts_zerocopy::AccountInfoRef;
 use crate::error::*;
+use crate::logs::*;
 use crate::state::*;
 use crate::token_utils::*;
 
@@ -67,6 +68,15 @@ pub fn place_order(ctx: Context<PlaceOrder>, order: Order, limit: u8) -> Result<
         limit,
         ctx.remaining_accounts,
     )?;
+
+    if let Some(order_id) = order_id {
+        emit!(PlaceOrderLog {
+            open_orders_account: open_orders_account_pk,
+            order_id,
+            timestamp: now_ts
+        })
+    }
+    
 
     let position = &mut open_orders_account.position;
     let deposit_amount = match order.side {

--- a/programs/openbook-v2/src/instructions/place_order.rs
+++ b/programs/openbook-v2/src/instructions/place_order.rs
@@ -4,7 +4,6 @@ use std::cmp;
 use crate::accounts_ix::*;
 use crate::accounts_zerocopy::AccountInfoRef;
 use crate::error::*;
-use crate::logs::*;
 use crate::state::*;
 use crate::token_utils::*;
 
@@ -68,15 +67,6 @@ pub fn place_order(ctx: Context<PlaceOrder>, order: Order, limit: u8) -> Result<
         limit,
         ctx.remaining_accounts,
     )?;
-
-    if let Some(order_id) = order_id {
-        emit!(PlaceOrderLog {
-            open_orders_account: open_orders_account_pk,
-            order_id,
-            timestamp: now_ts
-        })
-    }
-    
 
     let position = &mut open_orders_account.position;
     let deposit_amount = match order.side {

--- a/programs/openbook-v2/src/instructions/place_order.rs
+++ b/programs/openbook-v2/src/instructions/place_order.rs
@@ -59,6 +59,7 @@ pub fn place_order(ctx: Context<PlaceOrder>, order: Order, limit: u8) -> Result<
     } = book.new_order(
         &order,
         &mut market,
+        &ctx.accounts.market.key(),
         &mut event_heap,
         oracle_price,
         Some(&mut open_orders_account),

--- a/programs/openbook-v2/src/instructions/place_take_order.rs
+++ b/programs/openbook-v2/src/instructions/place_take_order.rs
@@ -50,6 +50,7 @@ pub fn place_take_order(ctx: Context<PlaceTakeOrder>, order: Order, limit: u8) -
     } = book.new_order(
         &order,
         &mut market,
+        &ctx.accounts.market.key(),
         &mut event_heap,
         oracle_price,
         None,

--- a/programs/openbook-v2/src/instructions/set_delegate.rs
+++ b/programs/openbook-v2/src/instructions/set_delegate.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 
 use crate::accounts_ix::*;
-use crate::logs::SetDelegateLog;
+use crate::logs::{emit_stack, SetDelegateLog};
 use crate::pubkey_option::NonZeroPubkeyOption;
 
 pub fn set_delegate(ctx: Context<SetDelegate>) -> Result<()> {
@@ -16,9 +16,9 @@ pub fn set_delegate(ctx: Context<SetDelegate>) -> Result<()> {
 
     account.delegate = delegate_account;
 
-    emit!(SetDelegateLog {
+    emit_stack(SetDelegateLog {
         open_orders_account: ctx.accounts.open_orders_account.key(),
-        delegate: delegate_account.into()
+        delegate: delegate_account.into(),
     });
 
     Ok(())

--- a/programs/openbook-v2/src/instructions/settle_funds.rs
+++ b/programs/openbook-v2/src/instructions/settle_funds.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 
 use crate::accounts_ix::*;
+use crate::logs::emit_stack;
 use crate::logs::SettleFundsLog;
 use crate::state::*;
 use crate::token_utils::*;
@@ -73,12 +74,12 @@ pub fn settle_funds<'info>(ctx: Context<'_, '_, '_, 'info, SettleFunds<'info>>) 
         seeds,
     )?;
 
-    emit!(SettleFundsLog {
+    emit_stack(SettleFundsLog {
         open_orders_account: ctx.accounts.open_orders_account.key(),
         base_native: pa.base_free_native,
         quote_native: pa.quote_free_native,
         referrer_rebate,
-        referrer: ctx.accounts.referrer_account.as_ref().map(|acc| acc.key())
+        referrer: ctx.accounts.referrer_account.as_ref().map(|acc| acc.key()),
     });
 
     pa.base_free_native = 0;

--- a/programs/openbook-v2/src/instructions/sweep_fees.rs
+++ b/programs/openbook-v2/src/instructions/sweep_fees.rs
@@ -2,7 +2,7 @@ use crate::state::market_seeds;
 use anchor_lang::prelude::*;
 
 use crate::accounts_ix::*;
-use crate::logs::SweepFeesLog;
+use crate::logs::{emit_stack, SweepFeesLog};
 use crate::token_utils::*;
 
 pub fn sweep_fees(ctx: Context<SweepFees>) -> Result<()> {
@@ -24,7 +24,7 @@ pub fn sweep_fees(ctx: Context<SweepFees>) -> Result<()> {
         seeds,
     )?;
 
-    emit!(SweepFeesLog {
+    emit_stack(SweepFeesLog {
         market: ctx.accounts.market.key(),
         amount,
         receiver: ctx.accounts.token_receiver_account.key(),

--- a/programs/openbook-v2/src/logs.rs
+++ b/programs/openbook-v2/src/logs.rs
@@ -1,6 +1,22 @@
 use anchor_lang::prelude::*;
 use borsh::BorshSerialize;
 
+#[inline(never)] // ensure fresh stack frame
+pub fn emit_stack<T: anchor_lang::Event>(e: T) {
+    use std::io::{Cursor, Write};
+
+    // stack buffer, stack frames are 4kb
+    let mut buffer = [0u8; 3000];
+
+    let mut cursor = Cursor::new(&mut buffer[..]);
+    cursor.write_all(&T::DISCRIMINATOR).unwrap();
+    e.serialize(&mut cursor)
+        .expect("event must fit into stack buffer");
+
+    let pos = cursor.position() as usize;
+    anchor_lang::solana_program::log::sol_log_data(&[&buffer[..pos]]);
+}
+
 #[event]
 pub struct DepositLog {
     pub open_orders_account: Pubkey,

--- a/programs/openbook-v2/src/logs.rs
+++ b/programs/openbook-v2/src/logs.rs
@@ -50,13 +50,6 @@ pub struct FillLog {
 }
 
 #[event]
-pub struct PlaceOrderLog {
-    pub open_orders_account: Pubkey,
-    pub order_id: u128,
-    pub timestamp: u64,
-}
-
-#[event]
 pub struct TakerSignatureLog {
     pub market: Pubkey,
     pub seq_num: u64,

--- a/programs/openbook-v2/src/logs.rs
+++ b/programs/openbook-v2/src/logs.rs
@@ -33,6 +33,14 @@ pub struct FillLog {
     pub quantity: i64, // number of base lots
 }
 
+
+#[event]
+pub struct PlaceOrderLog {
+    pub open_orders_account: Pubkey,
+    pub order_id: u128,
+    pub timestamp: u64,
+}
+
 #[event]
 pub struct MarketMetaDataLog {
     pub market: Pubkey,

--- a/programs/openbook-v2/src/logs.rs
+++ b/programs/openbook-v2/src/logs.rs
@@ -33,12 +33,17 @@ pub struct FillLog {
     pub quantity: i64, // number of base lots
 }
 
-
 #[event]
 pub struct PlaceOrderLog {
     pub open_orders_account: Pubkey,
     pub order_id: u128,
     pub timestamp: u64,
+}
+
+#[event]
+pub struct TakerSignatureLog {
+    pub market: Pubkey,
+    pub seq_num: u64,
 }
 
 #[event]

--- a/programs/openbook-v2/src/state/open_orders_account.rs
+++ b/programs/openbook-v2/src/state/open_orders_account.rs
@@ -211,7 +211,7 @@ impl OpenOrdersAccount {
             maker_slot: fill.maker_slot,
             maker_out: fill.maker_out(),
             timestamp: fill.timestamp,
-            seq_num: fill.seq_num,
+            seq_num: fill.market_seq_num,
             maker: fill.maker,
             maker_client_order_id: fill.maker_client_order_id,
             maker_fee: maker_fees,

--- a/programs/openbook-v2/src/state/open_orders_account.rs
+++ b/programs/openbook-v2/src/state/open_orders_account.rs
@@ -3,7 +3,7 @@ use derivative::Derivative;
 use static_assertions::const_assert_eq;
 use std::mem::size_of;
 
-use crate::logs::FillLog;
+use crate::logs::{emit_stack, FillLog};
 use crate::pubkey_option::NonZeroPubkeyOption;
 use crate::{error::*, logs::OpenOrdersPositionLog};
 
@@ -205,7 +205,7 @@ impl OpenOrdersAccount {
             0
         };
 
-        emit!(FillLog {
+        emit_stack(FillLog {
             market: self.market,
             taker_side: fill.taker_side,
             maker_slot: fill.maker_slot,
@@ -224,7 +224,7 @@ impl OpenOrdersAccount {
         });
 
         let pa = &self.position;
-        emit!(OpenOrdersPositionLog {
+        emit_stack(OpenOrdersPositionLog {
             owner: self.owner,
             open_orders_account_num: self.account_num,
             market: self.market,
@@ -236,7 +236,7 @@ impl OpenOrdersAccount {
             locked_maker_fees: pa.locked_maker_fees,
             referrer_rebates_available: pa.referrer_rebates_available,
             maker_volume: pa.maker_volume,
-            taker_volume: pa.taker_volume
+            taker_volume: pa.taker_volume,
         })
     }
 
@@ -260,7 +260,7 @@ impl OpenOrdersAccount {
         pa.referrer_rebates_available += referrer_amount;
         market.referrer_rebates_accrued += referrer_amount;
 
-        emit!(OpenOrdersPositionLog {
+        emit_stack(OpenOrdersPositionLog {
             owner: self.owner,
             open_orders_account_num: self.account_num,
             market: self.market,
@@ -272,7 +272,7 @@ impl OpenOrdersAccount {
             locked_maker_fees: pa.locked_maker_fees,
             referrer_rebates_available: pa.referrer_rebates_available,
             maker_volume: pa.maker_volume,
-            taker_volume: pa.taker_volume
+            taker_volume: pa.taker_volume,
         })
     }
 

--- a/programs/openbook-v2/src/state/orderbook/book.rs
+++ b/programs/openbook-v2/src/state/orderbook/book.rs
@@ -247,7 +247,7 @@ impl<'a> Orderbook<'a> {
                 match_base_lots,
             );
 
-            emit!(TakerSignatureLog {
+            emit_stack(TakerSignatureLog {
                 market: *market_pk,
                 seq_num: market.seq_num,
             });
@@ -310,7 +310,7 @@ impl<'a> Orderbook<'a> {
                 ),
             };
 
-            emit!(TotalOrderFillEvent {
+            emit_stack(TotalOrderFillEvent {
                 side: side.into(),
                 taker: *owner,
                 total_quantity_paid,
@@ -471,10 +471,10 @@ impl<'a> Orderbook<'a> {
         }
 
         let placed_order_id = if post_target.is_some() {
-            emit!(PlaceOrderLog {
+            emit_stack(PlaceOrderLog {
                 open_orders_account: *owner,
                 order_id,
-                timestamp: now_ts
+                timestamp: now_ts,
             });
             Some(order_id)
         } else {

--- a/programs/openbook-v2/src/state/orderbook/book.rs
+++ b/programs/openbook-v2/src/state/orderbook/book.rs
@@ -471,11 +471,6 @@ impl<'a> Orderbook<'a> {
         }
 
         let placed_order_id = if post_target.is_some() {
-            emit_stack(PlaceOrderLog {
-                open_orders_account: *owner,
-                order_id,
-                timestamp: now_ts,
-            });
             Some(order_id)
         } else {
             None

--- a/programs/openbook-v2/src/state/orderbook/book.rs
+++ b/programs/openbook-v2/src/state/orderbook/book.rs
@@ -1,4 +1,4 @@
-use crate::logs::TotalOrderFillEvent;
+use crate::logs::*;
 use crate::state::MAX_OPEN_ORDERS;
 use crate::{
     error::*,
@@ -465,6 +465,11 @@ impl<'a> Orderbook<'a> {
         }
 
         let placed_order_id = if post_target.is_some() {
+            emit!(PlaceOrderLog {
+                open_orders_account: *owner,
+                order_id,
+                timestamp: now_ts
+            });
             Some(order_id)
         } else {
             None

--- a/programs/openbook-v2/src/state/orderbook/book.rs
+++ b/programs/openbook-v2/src/state/orderbook/book.rs
@@ -63,6 +63,7 @@ impl<'a> Orderbook<'a> {
         &mut self,
         order: &Order,
         open_book_market: &mut Market,
+        market_pk: &Pubkey,
         event_heap: &mut EventHeap,
         oracle_price: Option<I80F48>,
         mut open_orders_account: Option<&mut OpenOrdersAccount>,
@@ -235,7 +236,7 @@ impl<'a> Orderbook<'a> {
                 maker_out,
                 best_opposing.node.owner_slot,
                 now_ts,
-                event_heap.header.seq_num,
+                market.seq_num,
                 best_opposing.node.owner,
                 best_opposing.node.client_order_id,
                 best_opposing.node.timestamp,
@@ -245,6 +246,11 @@ impl<'a> Orderbook<'a> {
                 best_opposing.node.peg_limit,
                 match_base_lots,
             );
+
+            emit!(TakerSignatureLog {
+                market: *market_pk,
+                seq_num: market.seq_num,
+            });
 
             process_fill_event(
                 fill,

--- a/programs/openbook-v2/src/state/orderbook/heap.rs
+++ b/programs/openbook-v2/src/state/orderbook/heap.rs
@@ -243,7 +243,7 @@ pub struct FillEvent {
     pub maker_slot: u8,
     pub padding: [u8; 4],
     pub timestamp: u64,
-    pub seq_num: u64,
+    pub market_seq_num: u64,
 
     pub maker: Pubkey,
 
@@ -269,7 +269,7 @@ impl FillEvent {
         maker_out: bool,
         maker_slot: u8,
         timestamp: u64,
-        seq_num: u64,
+        market_seq_num: u64,
         maker: Pubkey,
         maker_client_order_id: u64,
         maker_timestamp: u64,
@@ -285,7 +285,7 @@ impl FillEvent {
             maker_out: maker_out.into(),
             maker_slot,
             timestamp,
-            seq_num,
+            market_seq_num,
             maker,
             maker_client_order_id,
             maker_timestamp,

--- a/programs/openbook-v2/src/state/orderbook/mod.rs
+++ b/programs/openbook-v2/src/state/orderbook/mod.rs
@@ -96,6 +96,7 @@ mod tests {
     fn book_bids_full() {
         let (mut openbook_market, oracle_price, mut event_heap, book_accs) = test_setup(5000.0);
         let mut book = book_accs.orderbook();
+        let market_pk = Pubkey::new_unique();
 
         let mut new_order =
             |book: &mut Orderbook, event_heap: &mut EventHeap, side, price_lots, now_ts| -> u128 {
@@ -118,6 +119,7 @@ mod tests {
                         self_trade_behavior: SelfTradeBehavior::DecrementTake,
                     },
                     &mut openbook_market,
+                    &market_pk,
                     event_heap,
                     oracle_price,
                     Some(&mut account),
@@ -226,6 +228,7 @@ mod tests {
     fn book_new_order() {
         let (mut market, oracle_price, mut event_heap, book_accs) = test_setup(1000.0);
         let mut book = book_accs.orderbook();
+        let market_pk = Pubkey::new_unique();
 
         // Add lots and fees to make sure to exercise unit conversion
         market.base_lot_size = 10;
@@ -259,6 +262,7 @@ mod tests {
                 self_trade_behavior: SelfTradeBehavior::DecrementTake,
             },
             &mut market,
+            &market_pk,
             &mut event_heap,
             oracle_price,
             Some(&mut maker),
@@ -305,6 +309,7 @@ mod tests {
                 self_trade_behavior: SelfTradeBehavior::DecrementTake,
             },
             &mut market,
+            &market_pk,
             &mut event_heap,
             oracle_price,
             Some(&mut taker),
@@ -368,6 +373,7 @@ mod tests {
         let (mut market, oracle_price, mut event_heap, book_accs) = test_setup(5000.0);
         let quote_lot_size = market.quote_lot_size;
         let mut book = book_accs.orderbook();
+        let market_pk = Pubkey::new_unique();
 
         let mut new_order = |book: &mut Orderbook,
                              event_heap: &mut EventHeap,
@@ -392,6 +398,7 @@ mod tests {
                     self_trade_behavior: SelfTradeBehavior::DecrementTake,
                 },
                 &mut market,
+                &market_pk,
                 event_heap,
                 oracle_price,
                 Some(&mut account),


### PR DESCRIPTION
1. Add TakerSignatureLog to allow linking the Taker order to a cranked fill
2. Use emit_stack to save program heap space (difference in CU usage is negligible)