### PR TITLE
settle ix: don't require a mut owner

### DIFF
--- a/programs/openbook-v2/src/accounts_ix/settle_funds.rs
+++ b/programs/openbook-v2/src/accounts_ix/settle_funds.rs
@@ -5,7 +5,6 @@ use anchor_spl::token::{Token, TokenAccount};
 
 #[derive(Accounts)]
 pub struct SettleFunds<'info> {
-    #[account(mut)]
     pub owner: Signer<'info>,
     #[account(mut)]
     pub penalty_payer: Signer<'info>,


### PR DESCRIPTION
The owner has to sign, but its data is not even read.