### PR TITLE
Fix: wallet import for react/nextjs compatible

### DIFF
--- a/ts/client/src/utils/utils.ts
+++ b/ts/client/src/utils/utils.ts
@@ -11,7 +11,8 @@ import {
   TOKEN_PROGRAM_ID,
 } from '@solana/spl-token';
 import { OpenBookV2Client } from '..';
-import { AnchorProvider, Wallet } from '@coral-xyz/anchor';
+import { AnchorProvider } from '@coral-xyz/anchor';
+const { Wallet } = require("@coral-xyz/anchor");
 
 export const SideUtils = {
   Bid: { bid: {} },


### PR DESCRIPTION
I realize this looks a little wacky, but this was the only way I could get my nextjs app to build. Since [this change](https://github.com/openbook-dex/openbook-v2/pull/226/files#diff-1ab93de05dbf0753808ac9178aa0b838cca516105b9a24551dbaf35a24490469) to the TS client, nextjs will not build with this. You can read [other issues](https://stackoverflow.com/questions/71743279/attempted-import-error-wallet-is-not-exported-from-project-serum-anchor). About this. I don't know if someone has a better solution, but this was how I was able to get it to work. 

I had already tried this for the next.config:
```
experimental: {
        serverComponentsExternalPackages: ["@coral-xyz/anchor"],
      },
      ```

Sadly this didn't work even though it looked very promising. 