### PR TITLE
update market account struct name to match idl value

### DIFF
--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -576,7 +576,7 @@ export class OpenBookV2Client {
   }
 
   public decodeMarket(data: Buffer): any {
-    return this.program.coder.accounts.decode('Market', data);
+    return this.program.coder.accounts.decode('market', data);
   }
 
   public async placeOrderIx(


### PR DESCRIPTION
This fixes an error when decoding a v2 market account due to a mismatch between the struct name defined in the idl and the provided value