### PR TITLE
chore: add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,9 @@
     "ts-node": "^10.9.2",
     "typescript": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "homepage": "https://github.com/openbook-dex/openbook-v2#readme",
+  "bugs": {
+    "url": "https://github.com/openbook-dex/openbook-v2/issues"
+  }
 }


### PR DESCRIPTION
## Summary
- add npm homepage metadata pointing to the README
- add bugs.url metadata pointing to the issue tracker

## Verification
- checked package.json now exposes homepage and bugs metadata
- no runtime code changed